### PR TITLE
Populate Transaction with Nonce from web3Provider

### DIFF
--- a/ethsigner/build.gradle
+++ b/ethsigner/build.gradle
@@ -35,4 +35,5 @@ dependencies {
   integrationTestImplementation 'io.rest-assured:rest-assured'
   integrationTestImplementation 'org.assertj:assertj-core'
   integrationTestImplementation 'org.mock-server:mockserver-netty'
+  integrationTestImplementation 'org.mockito:mockito-core'
 }

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -17,6 +17,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
@@ -24,7 +28,6 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 import static org.web3j.utils.Async.defaultExecutorService;
 
-import tech.pegasys.ethsigner.RawTransactionConverter;
 import tech.pegasys.ethsigner.Runner;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.request.EthNodeRequest;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.request.EthRequestFactory;
@@ -32,12 +35,15 @@ import tech.pegasys.ethsigner.jsonrpcproxy.model.request.EthSignerRequest;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.response.EthNodeResponse;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.response.EthResponseFactory;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.response.EthSignerResponse;
+import tech.pegasys.ethsigner.requesthandler.sendtransaction.RawTransactionConverter;
+import tech.pegasys.ethsigner.requesthandler.sendtransaction.Web3jNonceProvider;
 import tech.pegasys.ethsigner.signing.ChainIdProvider;
 import tech.pegasys.ethsigner.signing.ConfigurationChainId;
 import tech.pegasys.ethsigner.signing.TransactionSigner;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.net.ServerSocket;
 import java.net.URL;
 import java.nio.file.Files;
@@ -62,6 +68,8 @@ import org.web3j.crypto.Credentials;
 import org.web3j.crypto.WalletUtils;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.JsonRpc2_0Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 
 public class IntegrationTestBase {
 
@@ -102,13 +110,23 @@ public class IntegrationTestBase {
     httpServerOptions.setPort(serverSocket.getLocalPort());
     httpServerOptions.setHost("localhost");
 
+    final Web3j web3j = mock(Web3j.class);
+    @SuppressWarnings("unchecked")
+    final Request<?, EthGetTransactionCount> rq =
+        (Request<String, EthGetTransactionCount>) mock(Request.class);
+    final EthGetTransactionCount ethGetTransactionCount = mock(EthGetTransactionCount.class);
+    when(ethGetTransactionCount.getTransactionCount()).thenReturn(BigInteger.ONE);
+    when(rq.send()).thenReturn(ethGetTransactionCount);
+    doReturn(rq).when(web3j).ethGetTransactionCount(any(), any());
+
     runner =
         new Runner(
             transactionSigner,
             httpClientOptions,
             httpServerOptions,
             Duration.ofSeconds(5),
-            new RawTransactionConverter());
+            new RawTransactionConverter(
+                new Web3jNonceProvider(web3j, transactionSigner.getAddress())));
     runner.start();
 
     LOG.info(

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -24,35 +24,6 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 import static org.web3j.utils.Async.defaultExecutorService;
 
-import com.google.common.io.Resources;
-import io.restassured.RestAssured;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.json.JsonObject;
-import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.Header;
-import org.mockserver.model.HttpRequest;
-import org.mockserver.model.RegexBody;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.web3j.crypto.CipherException;
-import org.web3j.crypto.Credentials;
-import org.web3j.crypto.WalletUtils;
-import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.JsonRpc2_0Web3j;
-import org.web3j.protocol.http.HttpService;
 import tech.pegasys.ethsigner.Runner;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.request.EthNodeRequest;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.request.EthRequestFactory;
@@ -65,6 +36,35 @@ import tech.pegasys.ethsigner.requesthandler.sendtransaction.Web3jNonceProvider;
 import tech.pegasys.ethsigner.signing.ChainIdProvider;
 import tech.pegasys.ethsigner.signing.ConfigurationChainId;
 import tech.pegasys.ethsigner.signing.TransactionSigner;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.io.Resources;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.web3j.crypto.CipherException;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.JsonRpc2_0Web3j;
+import org.web3j.protocol.http.HttpService;
 
 public class IntegrationTestBase {
 
@@ -112,7 +112,8 @@ public class IntegrationTestBase {
                     + httpClientOptions.getDefaultHost()
                     + ":"
                     + httpClientOptions.getDefaultPort()),
-            2000, defaultExecutorService());
+            2000,
+            defaultExecutorService());
 
     runner =
         new Runner(

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
@@ -61,10 +61,10 @@ public class SigningSendTransactionIntegrationTest extends IntegrationTestBase {
         .respond(response(generateTransactionCountResponse()));
 
     final String ethNodeResponseBody = "VALID_RESPONSE";
-    final String responseBody =
+    final String requestBody =
         sendRawTransaction.request(
             "0xf892808609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567536a0eab405b58d6aa7db96ebfab8c55825504090447d6209848eeca5a2a2ff909467a064712627fdf02027521a716b8e9a497d31f7c4d5ecb75840fde86ade1d726fab");
-    setUpEthNodeResponse(request.ethNode(responseBody), response.ethNode(ethNodeResponseBody));
+    setUpEthNodeResponse(request.ethNode(requestBody), response.ethNode(ethNodeResponseBody));
 
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(ethNodeResponseBody));

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
@@ -12,8 +12,11 @@
  */
 package tech.pegasys.ethsigner.jsonrpcproxy;
 
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 import static tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError.INVALID_PARAMS;
 
+import org.mockserver.model.RegexBody;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendRawTransaction;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendTransaction;
 
@@ -53,13 +56,14 @@ public class SigningSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   public void missingNonceResultsInEthNodeRespondingSuccessfully() {
+    clientAndServer.when(request()
+        .withBody(new RegexBody(".*eth_getTransactionCount.*")))
+        .respond(response(generateTransactionCountResponse()));
+
     final String ethNodeResponseBody = "VALID_RESPONSE";
     final String responseBody =
         sendRawTransaction.request(
-            "0xf892018609184e72a0008276c094d46e8dd67c5d32be8058bb8eb97087"
-                + "0f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058"
-                + "bb8eb970870f07244567535a05b2b6e380da44241ecd30b21bd56f05da80e217a6347dfe06b0fb0"
-                + "0b2e4adc14a048c4f0255bdb5526171b0a771e61b9f44b3c3fca2feffae04d1748297726ca0f");
+            "0xf892808609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567536a0eab405b58d6aa7db96ebfab8c55825504090447d6209848eeca5a2a2ff909467a064712627fdf02027521a716b8e9a497d31f7c4d5ecb75840fde86ade1d726fab");
     setUpEthNodeResponse(request.ethNode(responseBody), response.ethNode(ethNodeResponseBody));
 
     sendRequestThenVerifyResponse(

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
@@ -56,10 +56,10 @@ public class SigningSendTransactionIntegrationTest extends IntegrationTestBase {
     final String ethNodeResponseBody = "VALID_RESPONSE";
     final String responseBody =
         sendRawTransaction.request(
-            "0xf892028609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d4"
-                + "6e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
-                + "35a075f183cd476f88597e60c594a01932fa24b25b8d8fa3d817cb4d77b1af7918e3a026830ee5e7"
-                + "166baf2faf2fef649bcc3299ff47037c16ab11b9d5176fc9eee9b3");
+            "0xf892018609184e72a0008276c094d46e8dd67c5d32be8058bb8eb97087"
+                + "0f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058"
+                + "bb8eb970870f07244567535a05b2b6e380da44241ecd30b21bd56f05da80e217a6347dfe06b0fb0"
+                + "0b2e4adc14a048c4f0255bdb5526171b0a771e61b9f44b3c3fca2feffae04d1748297726ca0f");
     setUpEthNodeResponse(request.ethNode(responseBody), response.ethNode(ethNodeResponseBody));
 
     sendRequestThenVerifyResponse(

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.ethsigner.jsonrpcproxy;
 
-import static tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError.INTERNAL_ERROR;
 import static tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError.INVALID_PARAMS;
 
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendRawTransaction;
@@ -53,10 +52,18 @@ public class SigningSendTransactionIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
-  public void internalErrorResponseWhenMissingNonce() {
-    // TODO This behaviour will change with the get nonce (PIE-1468)
+  public void missingNonceResultsInEthNodeRespondingSuccessfully() {
+    final String ethNodeResponseBody = "VALID_RESPONSE";
+    final String responseBody =
+        sendRawTransaction.request(
+            "0xf892028609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d4"
+                + "6e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
+                + "35a075f183cd476f88597e60c594a01932fa24b25b8d8fa3d817cb4d77b1af7918e3a026830ee5e7"
+                + "166baf2faf2fef649bcc3299ff47037c16ab11b9d5176fc9eee9b3");
+    setUpEthNodeResponse(request.ethNode(responseBody), response.ethNode(ethNodeResponseBody));
+
     sendRequestThenVerifyResponse(
-        request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(INTERNAL_ERROR));
+        request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(ethNodeResponseBody));
   }
 
   @Test

--- a/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
+++ b/ethsigner/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningSendTransactionIntegrationTest.java
@@ -16,7 +16,6 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError.INVALID_PARAMS;
 
-import org.mockserver.model.RegexBody;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendRawTransaction;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendTransaction;
 
@@ -24,6 +23,7 @@ import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockserver.model.RegexBody;
 import org.web3j.crypto.CipherException;
 
 /** Signing is a step during proxying a sendTransaction() JSON-RPC request to an Ethereum node. */
@@ -56,8 +56,8 @@ public class SigningSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   public void missingNonceResultsInEthNodeRespondingSuccessfully() {
-    clientAndServer.when(request()
-        .withBody(new RegexBody(".*eth_getTransactionCount.*")))
+    clientAndServer
+        .when(request().withBody(new RegexBody(".*eth_getTransactionCount.*")))
         .respond(response(generateTransactionCountResponse()));
 
     final String ethNodeResponseBody = "VALID_RESPONSE";

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/Runner.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/Runner.java
@@ -12,14 +12,15 @@
  */
 package tech.pegasys.ethsigner;
 
-import tech.pegasys.ethsigner.jsonrpcproxy.EthAccountsBodyProvider;
-import tech.pegasys.ethsigner.jsonrpcproxy.HttpResponseFactory;
-import tech.pegasys.ethsigner.jsonrpcproxy.InternalResponseHandler;
-import tech.pegasys.ethsigner.jsonrpcproxy.JsonRpcErrorReporter;
-import tech.pegasys.ethsigner.jsonrpcproxy.JsonRpcHttpService;
-import tech.pegasys.ethsigner.jsonrpcproxy.PassThroughHandler;
-import tech.pegasys.ethsigner.jsonrpcproxy.RequestMapper;
-import tech.pegasys.ethsigner.jsonrpcproxy.SendTransactionHandler;
+import tech.pegasys.ethsigner.http.HttpResponseFactory;
+import tech.pegasys.ethsigner.http.JsonRpcHttpService;
+import tech.pegasys.ethsigner.http.RequestMapper;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcErrorReporter;
+import tech.pegasys.ethsigner.requesthandler.internalresponse.EthAccountsBodyProvider;
+import tech.pegasys.ethsigner.requesthandler.internalresponse.InternalResponseHandler;
+import tech.pegasys.ethsigner.requesthandler.passthrough.PassThroughHandler;
+import tech.pegasys.ethsigner.requesthandler.sendtransaction.RawTransactionConverter;
+import tech.pegasys.ethsigner.requesthandler.sendtransaction.SendTransactionHandler;
 import tech.pegasys.ethsigner.signing.TransactionSigner;
 
 import java.time.Duration;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/RunnerBuilder.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/RunnerBuilder.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.ethsigner;
 
+import tech.pegasys.ethsigner.requesthandler.sendtransaction.RawTransactionConverter;
 import tech.pegasys.ethsigner.signing.TransactionSigner;
 
 import java.time.Duration;
@@ -33,24 +34,29 @@ public class RunnerBuilder {
 
   public RunnerBuilder() {}
 
-  public void setTransactionSigner(final TransactionSigner transactionSigner) {
+  public RunnerBuilder setTransactionSigner(final TransactionSigner transactionSigner) {
     this.transactionSigner = transactionSigner;
+    return this;
   }
 
-  public void setClientOptions(final WebClientOptions clientOptions) {
+  public RunnerBuilder setClientOptions(final WebClientOptions clientOptions) {
     this.clientOptions = clientOptions;
+    return this;
   }
 
-  public void setServerOptions(final HttpServerOptions serverOptions) {
+  public RunnerBuilder setServerOptions(final HttpServerOptions serverOptions) {
     this.serverOptions = serverOptions;
+    return this;
   }
 
-  public void setHttpRequestTimeout(final Duration requestTimeout) {
+  public RunnerBuilder setHttpRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+    return this;
   }
 
-  public void setTransactionConverter(final RawTransactionConverter transactionConverter) {
+  public RunnerBuilder setTransactionConverter(final RawTransactionConverter transactionConverter) {
     this.transactionConverter = transactionConverter;
+    return this;
   }
 
   public Runner build() {

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/http/HttpResponseFactory.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/http/HttpResponseFactory.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.http;
 
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcResponse;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/http/JsonRpcHttpService.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/http/JsonRpcHttpService.java
@@ -10,11 +10,12 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.http;
 
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcErrorResponse;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
 
 import java.time.Duration;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/http/LogErrorHandler.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/http/LogErrorHandler.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.http;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/http/RequestMapper.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/http/RequestMapper.java
@@ -10,7 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.http;
+
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/BodyProvider.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/BodyProvider.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler;
 
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcBody.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcBody.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler;
 
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcErrorResponse;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcErrorReporter.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcErrorReporter.java
@@ -10,8 +10,9 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler;
 
+import tech.pegasys.ethsigner.http.HttpResponseFactory;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcErrorResponse;
 
@@ -31,7 +32,7 @@ public class JsonRpcErrorReporter {
     this.responder = responder;
   }
 
-  void send(
+  public void send(
       final JsonRpcRequest jsonRequest,
       final HttpServerRequest httpRequest,
       final JsonRpcErrorResponse error) {

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcRequestHandler.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/JsonRpcRequestHandler.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler;
 
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/internalresponse/EthAccountsBodyProvider.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/internalresponse/EthAccountsBodyProvider.java
@@ -10,7 +10,7 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler.internalresponse;
 
 import static java.util.Collections.singletonList;
 
@@ -18,6 +18,8 @@ import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcErrorResponse;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcSuccessResponse;
+import tech.pegasys.ethsigner.requesthandler.BodyProvider;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcBody;
 
 import java.util.Collection;
 

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/internalresponse/InternalResponseHandler.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/internalresponse/InternalResponseHandler.java
@@ -10,10 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler.internalresponse;
 
+import tech.pegasys.ethsigner.http.HttpResponseFactory;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcSuccessResponse;
+import tech.pegasys.ethsigner.requesthandler.BodyProvider;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcBody;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcErrorReporter;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpServerRequest;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/passthrough/PassThroughHandler.java
@@ -10,9 +10,10 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler.passthrough;
 
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/NonceProvider.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/NonceProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.requesthandler.sendtransaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+public interface NonceProvider {
+
+  BigInteger getNonce() throws IOException;
+}

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/RawTransactionConverter.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/RawTransactionConverter.java
@@ -10,36 +10,50 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner;
+package tech.pegasys.ethsigner.requesthandler.sendtransaction;
 
 import tech.pegasys.ethsigner.jsonrpc.SendTransactionJsonParameters;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Optional;
 
 import org.web3j.crypto.RawTransaction;
 
 public class RawTransactionConverter {
+  private final NonceProvider nonceProvider;
 
-  public RawTransaction from(final SendTransactionJsonParameters input) {
+  public RawTransactionConverter(final NonceProvider nonceProvider) {
+    this.nonceProvider = nonceProvider;
+  }
+
+  public RawTransaction from(final SendTransactionJsonParameters input) throws IOException {
+
     return RawTransaction.createTransaction(
-        valueOrDefault(input.nonce(), null),
-        valueOrDefault(input.gasPrice(), BigInteger.ZERO),
-        valueOrDefault(input.gas(), BigInteger.valueOf(90000)),
-        valueOrDefault(input.receiver(), ""),
-        valueOrDefault(input.value(), BigInteger.ZERO),
+        valueOrDefault(input.nonce(), nonceProvider::getNonce),
+        valueOrDefault(input.gasPrice(), () -> BigInteger.ZERO),
+        valueOrDefault(input.gas(), () -> BigInteger.valueOf(90000)),
+        valueOrDefault(input.receiver(), () -> ""),
+        valueOrDefault(input.value(), () -> BigInteger.ZERO),
         input.data());
   }
 
-  private <T> T valueOrDefault(Optional<T> value, final T defaultValue) {
+  private <T> T valueOrDefault(
+      final Optional<T> value, final ThrowingSupplier<T> alternateValueSupplier)
+      throws IOException {
     if (value.isPresent()) {
       return value.get();
     }
 
-    if (defaultValue != null) {
-      return defaultValue;
+    if (alternateValueSupplier != null) {
+      return alternateValueSupplier.get();
     } else {
       throw new RuntimeException("Unable to have a default value of null.");
     }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingSupplier<T> {
+    T get() throws IOException;
   }
 }

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -10,16 +10,18 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner.jsonrpcproxy;
+package tech.pegasys.ethsigner.requesthandler.sendtransaction;
 
 import static java.util.Collections.singletonList;
 
-import tech.pegasys.ethsigner.RawTransactionConverter;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequestId;
 import tech.pegasys.ethsigner.jsonrpc.SendTransactionJsonParameters;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcErrorResponse;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcBody;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcErrorReporter;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
 import tech.pegasys.ethsigner.signing.TransactionSigner;
 
 import io.vertx.core.buffer.Buffer;

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProvider.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProvider.java
@@ -36,7 +36,7 @@ public class Web3jNonceProvider implements NonceProvider {
 
   @Override
   public BigInteger getNonce() throws IOException {
-    return getNonceFromClient().add(BigInteger.ONE);
+    return getNonceFromClient();
   }
 
   private BigInteger getNonceFromClient() throws IOException {

--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProvider.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.requesthandler.sendtransaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+
+public class Web3jNonceProvider implements NonceProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Web3jNonceProvider.class);
+
+  private final Web3j web3j;
+  private final String accountAddress;
+
+  public Web3jNonceProvider(final Web3j web3j, final String accountAddress) {
+    this.web3j = web3j;
+    this.accountAddress = accountAddress;
+  }
+
+  @Override
+  public BigInteger getNonce() throws IOException {
+    return getNonceFromClient().add(BigInteger.ONE);
+  }
+
+  private BigInteger getNonceFromClient() throws IOException {
+    final Request<?, EthGetTransactionCount> request =
+        web3j.ethGetTransactionCount(accountAddress, DefaultBlockParameterName.LATEST);
+    try {
+      final EthGetTransactionCount count = request.send();
+      return count.getTransactionCount();
+    } catch (final IOException e) {
+      LOG.info("Failed to determine nonce from downstream handler.", e);
+      throw e;
+    }
+  }
+}

--- a/ethsigner/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsBodyProviderTest.java
+++ b/ethsigner/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsBodyProviderTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.jsonrpc.JsonRpcRequestId;
 import tech.pegasys.ethsigner.jsonrpc.response.JsonRpcError;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcBody;
+import tech.pegasys.ethsigner.requesthandler.internalresponse.EthAccountsBodyProvider;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;

--- a/ethsigner/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/RequestMapperTest.java
+++ b/ethsigner/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/RequestMapperTest.java
@@ -14,6 +14,9 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import tech.pegasys.ethsigner.http.RequestMapper;
+import tech.pegasys.ethsigner.requesthandler.JsonRpcRequestHandler;
+
 import com.google.common.collect.ImmutableMap;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;

--- a/ethsigner/src/test/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProviderTest.java
+++ b/ethsigner/src/test/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProviderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.requesthandler.sendtransaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.Request;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Web3jNonceProviderTest {
+
+  @Mock private Web3j web3j;
+
+  @Mock private Request<?, EthGetTransactionCount> request;
+
+  @Mock private EthGetTransactionCount ethGetTransactionCount;
+
+  private final String accountAddress = "1122334455667788990011223344556677889900";
+
+  private final BigInteger priorTransactionCount = BigInteger.TEN;
+
+  @Before
+  public void setup() throws IOException {
+    when(ethGetTransactionCount.getTransactionCount()).thenReturn(priorTransactionCount);
+    when(request.send()).thenReturn(ethGetTransactionCount);
+    doReturn(request).when(web3j).ethGetTransactionCount(eq(accountAddress), any());
+  }
+
+  @Test
+  public void followingInitialisationGrabsNonceFromWeb3jProvider() throws IOException {
+    final Web3jNonceProvider nonceProvider = new Web3jNonceProvider(web3j, accountAddress);
+
+    assertThat(nonceProvider.getNonce()).isEqualTo(priorTransactionCount.add(BigInteger.ONE));
+
+    verify(request).send();
+    verify(ethGetTransactionCount).getTransactionCount();
+  }
+}

--- a/ethsigner/src/test/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProviderTest.java
+++ b/ethsigner/src/test/java/tech/pegasys/ethsigner/requesthandler/sendtransaction/Web3jNonceProviderTest.java
@@ -52,10 +52,10 @@ public class Web3jNonceProviderTest {
   }
 
   @Test
-  public void followingInitialisationGrabsNonceFromWeb3jProvider() throws IOException {
+  public void returnsValueAsReceivedFromWeb3jProvider() throws IOException {
     final Web3jNonceProvider nonceProvider = new Web3jNonceProvider(web3j, accountAddress);
 
-    assertThat(nonceProvider.getNonce()).isEqualTo(priorTransactionCount.add(BigInteger.ONE));
+    assertThat(nonceProvider.getNonce()).isEqualTo(priorTransactionCount);
 
     verify(request).send();
     verify(ethGetTransactionCount).getTransactionCount();


### PR DESCRIPTION
If a "SendTransaction" Json RPC is received, and it does not contain a nonce, the EthSigner will attempt to populate it using either a value as extracted from the downstream web3-provider, or the last good value.

If the Nonce is still too low, the nonce-too-low error is bubbled back to the caller - however this will be changed in future PRs whereby the NONCE_TOO_LOW will be captured, a new nonce created and the transaction re-submitted.