### PR TITLE
Fix web3j endpoint to use the hostname, not the object string.

### DIFF
--- a/ethsigner/src/main/java/tech/pegasys/ethsigner/EthSigner.java
+++ b/ethsigner/src/main/java/tech/pegasys/ethsigner/EthSigner.java
@@ -67,13 +67,13 @@ public final class EthSigner {
     }
 
     try {
-      final Web3j web3j =
-          new JsonRpc2_0Web3j(
-              new HttpService(
-                  "http://"
-                      + config.getDownstreamHttpHost()
-                      + ":"
-                      + config.getDownstreamHttpPort()));
+      final String downstreamUrl =
+          "http://"
+              + config.getDownstreamHttpHost().getHostName()
+              + ":"
+              + config.getDownstreamHttpPort();
+      LOG.info("Downstream URL = {}", downstreamUrl);
+      final Web3j web3j = new JsonRpc2_0Web3j(new HttpService(downstreamUrl));
       final FileBasedTransactionSigner signer =
           FileBasedTransactionSigner.createFrom(config.getKeyPath().toFile(), password.get());
 

--- a/ethsigner/src/test/java/tech/pegasys/ethsigner/EthSignerCommandLineConfigTest.java
+++ b/ethsigner/src/test/java/tech/pegasys/ethsigner/EthSignerCommandLineConfigTest.java
@@ -135,4 +135,22 @@ public class EthSignerCommandLineConfigTest {
     assertThat(actualValueGetter.get()).isEqualTo(expectedValue);
     assertThat(commandOutput.toString()).isEmpty();
   }
+
+  @Test
+  public void domainNamesDecodeIntoAnInetAddress() {
+    final String input =
+        "--key-file=./keyfile "
+            + "--password-file=./passwordFile "
+            + "--downstream-http-host=google.com "
+            + "--downstream-http-port=5000 "
+            + "--downstream-http-request-timeout=10000 "
+            + "--http-listen-port=5001 "
+            + "--http-listen-host=localhost "
+            + "--chain-id=6 "
+            + "--logging=INFO";
+
+    final boolean result = parseCommand(input);
+    assertThat(result).isTrue();
+    assertThat(config.getDownstreamHttpHost().getHostName()).isEqualTo("google.com");
+  }
 }


### PR DESCRIPTION
In EthSigner, when constructing the Web3j endpoint, the string was constructed of an InetAddress and a port number - rather than the hostname _within_ the InetAddress, thus the web3j connection was:

http://<hostname>/<ip_addr>:port - which fails to connect when used.