### PR TITLE
fix google console meta id

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ extra:
     pegasys_website: https://pegasys.tech/
     issues: https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10000
   google:
-    site_verification: 'sOGxkFMvKU1k-nuvDkmIAmadWopy6Sam2DMgzltBoMo'
+    site_verification: 'za1cLzyS6LXDGO-pMzvfQdYTZ0Zc67uZtY0asA4YXZ0'
     tag_manager: 'GTM-5VXGSDM'
 
 


### PR DESCRIPTION
fix google console meta id that was not the right one... oups...

The right one should generate `<meta name="google-site-verification" content="za1cLzyS6LXDGO-pMzvfQdYTZ0Zc67uZtY0asA4YXZ0" />`
