### PR TITLE
Reject transactions sent using eea_sendTransaction with a non-zero value

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/AcceptanceTestBase.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/AcceptanceTestBase.java
@@ -49,7 +49,7 @@ public class AcceptanceTestBase {
     return ethNode;
   }
 
-  protected String enclavePublicKey1() {
+  protected String enclavePublicKey() {
     return readResource("enclave_key.pub");
   }
 

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/PrivateTransaction.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/PrivateTransaction.java
@@ -80,6 +80,29 @@ public class PrivateTransaction {
         restriction);
   }
 
+  public static PrivateTransaction createEtherTransaction(
+      final String from,
+      final BigInteger nonce,
+      final BigInteger gasPrice,
+      final BigInteger gasLimit,
+      final String to,
+      final BigInteger value,
+      final String privateFrom,
+      final List<String> privateFor,
+      final String restriction) {
+    return new PrivateTransaction(
+        from,
+        encodeQuantity(nonce),
+        encodeQuantity(gasPrice),
+        encodeQuantity(gasLimit),
+        to,
+        encodeQuantity(value),
+        null,
+        privateFrom,
+        privateFor,
+        restriction);
+  }
+
   public String getFrom() {
     return from;
   }

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
@@ -56,7 +56,7 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   public void valueTransferWithNonZeroValue() {
-    final PrivateTransaction contract =
+    final PrivateTransaction transaction =
         PrivateTransaction.createEtherTransaction(
             richBenefactor().address(),
             richBenefactor().nextNonceAndIncrement(),
@@ -69,7 +69,7 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
             RESTRICTED);
 
     final SignerResponse<JsonRpcErrorResponse> signerResponse =
-        ethSigner().privateContracts().submitExceptional(contract);
+        ethSigner().privateContracts().submitExceptional(transaction);
     assertThat(signerResponse.jsonRpc().getError()).isEqualTo(INVALID_PARAMS);
   }
 }

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
@@ -15,6 +15,7 @@ package tech.pegasys.ethsigner.tests.signing;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.ENCLAVE_ERROR;
+import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.INVALID_PARAMS;
 import static tech.pegasys.ethsigner.tests.dsl.Contracts.GAS_LIMIT;
 import static tech.pegasys.ethsigner.tests.dsl.Contracts.GAS_PRICE;
 import static tech.pegasys.ethsigner.tests.dsl.PrivateTransaction.RESTRICTED;
@@ -30,6 +31,7 @@ import java.math.BigInteger;
 import org.junit.Test;
 
 public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
+  private static final String RECIPIENT = "0x1b00ba00ca00bb00aa00bc00be00ac00ca00da00";
 
   @Test
   public void deployContract() {
@@ -41,8 +43,8 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
             GAS_LIMIT,
             BigInteger.ZERO,
             SimpleStorage.BINARY,
-            enclavePublicKey1(),
-            singletonList(enclavePublicKey1()),
+            enclavePublicKey(),
+            singletonList(enclavePublicKey()),
             RESTRICTED);
 
     final SignerResponse<JsonRpcErrorResponse> signerResponse =
@@ -50,5 +52,24 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
     // We expect this to fail with enclave error as we don't have orion running. If rlp decode fails
     // then we would get a different error
     assertThat(signerResponse.jsonRpc().getError()).isEqualTo(ENCLAVE_ERROR);
+  }
+
+  @Test
+  public void valueTransferWithNonZeroValue() {
+    final PrivateTransaction contract =
+        PrivateTransaction.createEtherTransaction(
+            richBenefactor().address(),
+            richBenefactor().nextNonceAndIncrement(),
+            GAS_PRICE,
+            GAS_LIMIT,
+            RECIPIENT,
+            BigInteger.ONE,
+            enclavePublicKey(),
+            singletonList(enclavePublicKey()),
+            RESTRICTED);
+
+    final SignerResponse<JsonRpcErrorResponse> signerResponse =
+        ethSigner().privateContracts().submitExceptional(contract);
+    assertThat(signerResponse.jsonRpc().getError()).isEqualTo(INVALID_PARAMS);
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParameters.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParameters.java
@@ -75,13 +75,8 @@ public class EeaSendTransactionJsonParameters {
 
   @JsonSetter("value")
   public void value(final String value) {
-    final BigInteger decodedValue = decodeQuantity(value);
-    if (decodedValue.equals(BigInteger.ZERO)) {
-      this.value = decodedValue;
-    } else {
-      throw new IllegalArgumentException(
-          "Non-zero value, private transactions cannot transfer ether");
-    }
+    validateValue(value);
+    this.value = decodeQuantity(value);
   }
 
   @JsonSetter("data")
@@ -131,5 +126,12 @@ public class EeaSendTransactionJsonParameters {
 
   public static EeaSendTransactionJsonParameters from(final JsonRpcRequest request) {
     return fromRpcRequestToJsonParam(EeaSendTransactionJsonParameters.class, request);
+  }
+
+  private void validateValue(final String value) {
+    if (!decodeQuantity(value).equals(BigInteger.ZERO)) {
+      throw new IllegalArgumentException(
+          "Non-zero value, private transactions cannot transfer ether");
+    }
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParameters.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParameters.java
@@ -75,7 +75,13 @@ public class EeaSendTransactionJsonParameters {
 
   @JsonSetter("value")
   public void value(final String value) {
-    this.value = decodeQuantity(value);
+    final BigInteger decodedValue = decodeQuantity(value);
+    if (decodedValue.equals(BigInteger.ZERO)) {
+      this.value = decodedValue;
+    } else {
+      throw new IllegalArgumentException(
+          "Non-zero value, private transactions cannot transfer ether");
+    }
   }
 
   @JsonSetter("data")

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
@@ -35,7 +35,8 @@ public class EthSendTransactionJsonParameters {
   private String data;
 
   @JsonCreator
-  public EthSendTransactionJsonParameters(@JsonProperty("from") final String sender) {
+  public EthSendTransactionJsonParameters(
+      @JsonProperty(value = "from", required = true) final String sender) {
     validatePrefix(sender);
     this.sender = sender;
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
@@ -35,8 +35,7 @@ public class EthSendTransactionJsonParameters {
   private String data;
 
   @JsonCreator
-  public EthSendTransactionJsonParameters(
-      @JsonProperty(value = "from", required = true) final String sender) {
+  public EthSendTransactionJsonParameters(@JsonProperty("from") final String sender) {
     validatePrefix(sender);
     this.sender = sender;
   }

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParametersTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParametersTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core.jsonrpc;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+public class EeaSendTransactionJsonParametersTest {
+
+  private Optional<BigInteger> getStringAsOptionalBigInteger(
+      final JsonObject object, final String key) {
+    final String value = object.getString(key);
+    return Optional.of(new BigInteger(value.substring(2), 16));
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Object> getAsArray(final JsonObject parameters, final String key) {
+    return parameters.getJsonArray(key).getList();
+  }
+
+  @Test
+  public void transactionStoredInJsonArrayCanBeDecoded() {
+    final JsonObject parameters = new JsonObject();
+    parameters.put("from", "0xb60e8dd61c5d32be8058bb8eb970870f07233155");
+    parameters.put("to", "0xd46e8dd67c5d32be8058bb8eb970870f07244567");
+    parameters.put("nonce", "0x1");
+    parameters.put("gas", "0x76c0");
+    parameters.put("gasPrice", "0x9184e72a000");
+    parameters.put("value", "0x0");
+    parameters.put(
+        "data",
+        "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675");
+    parameters.put("privateFrom", "ZlapEsl9qDLPy/e88+/6yvCUEVIvH83y0N4A6wHuKXI=");
+    parameters.put("privateFor", singletonList("GV8m0VZAccYGAAYMBuYQtKEj0XtpXeaw2APcoBmtA2w="));
+    parameters.put("restriction", "restricted");
+
+    final JsonArray inputParameters = new JsonArray();
+    inputParameters.add(parameters);
+
+    final JsonObject input = new JsonObject();
+    input.put("jsonrpc", 2.0);
+    input.put("method", "mine");
+    input.put("params", inputParameters);
+
+    final JsonRpcRequest request = input.mapTo(JsonRpcRequest.class);
+    final EeaSendTransactionJsonParameters txnParams =
+        EeaSendTransactionJsonParameters.from(request);
+
+    assertThat(txnParams.gas()).isEqualTo(getStringAsOptionalBigInteger(parameters, "gas"));
+    assertThat(txnParams.gasPrice())
+        .isEqualTo(getStringAsOptionalBigInteger(parameters, "gasPrice"));
+    assertThat(txnParams.nonce()).isEqualTo(getStringAsOptionalBigInteger(parameters, "nonce"));
+    assertThat(txnParams.receiver()).isEqualTo(Optional.of(parameters.getString("to")));
+    assertThat(txnParams.value()).isEqualTo(getStringAsOptionalBigInteger(parameters, "value"));
+    assertThat(txnParams.privateFrom()).isEqualTo(parameters.getString("privateFrom"));
+    assertThat(txnParams.privateFor()).isEqualTo(getAsArray(parameters, "privateFor"));
+    assertThat(txnParams.restriction()).isEqualTo(parameters.getString("restriction"));
+  }
+
+  @Test
+  public void transactionNotStoredInJsonArrayCanBeDecoded() {
+    final JsonObject parameters = new JsonObject();
+    parameters.put("from", "0xb60e8dd61c5d32be8058bb8eb970870f07233155");
+    parameters.put("to", "0xd46e8dd67c5d32be8058bb8eb970870f07244567");
+    parameters.put("nonce", "0x1");
+    parameters.put("gas", "0x76c0");
+    parameters.put("gasPrice", "0x9184e72a000");
+    parameters.put("value", "0x0");
+    parameters.put(
+        "data",
+        "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675");
+    parameters.put("privateFrom", "ZlapEsl9qDLPy/e88+/6yvCUEVIvH83y0N4A6wHuKXI=");
+    parameters.put("privateFor", singletonList("GV8m0VZAccYGAAYMBuYQtKEj0XtpXeaw2APcoBmtA2w="));
+    parameters.put("restriction", "restricted");
+
+    final JsonObject input = new JsonObject();
+    input.put("jsonrpc", 2.0);
+    input.put("method", "mine");
+    input.put("params", parameters);
+
+    final JsonRpcRequest request = input.mapTo(JsonRpcRequest.class);
+    final EeaSendTransactionJsonParameters txnParams =
+        EeaSendTransactionJsonParameters.from(request);
+
+    assertThat(txnParams.gas()).isEqualTo(getStringAsOptionalBigInteger(parameters, "gas"));
+    assertThat(txnParams.gasPrice())
+        .isEqualTo(getStringAsOptionalBigInteger(parameters, "gasPrice"));
+    assertThat(txnParams.nonce()).isEqualTo(getStringAsOptionalBigInteger(parameters, "nonce"));
+    assertThat(txnParams.receiver()).isEqualTo(Optional.of(parameters.getString("to")));
+    assertThat(txnParams.value()).isEqualTo(getStringAsOptionalBigInteger(parameters, "value"));
+    assertThat(txnParams.privateFrom()).isEqualTo(parameters.getString("privateFrom"));
+    assertThat(txnParams.privateFor()).isEqualTo(getAsArray(parameters, "privateFor"));
+    assertThat(txnParams.restriction()).isEqualTo(parameters.getString("restriction"));
+  }
+
+  @Test
+  public void transactionWithNonZeroValueFails() {
+    final JsonObject parameters = new JsonObject();
+    parameters.put("from", "0xb60e8dd61c5d32be8058bb8eb970870f07233155");
+    parameters.put("to", "0xd46e8dd67c5d32be8058bb8eb970870f07244567");
+    parameters.put("nonce", "0x1");
+    parameters.put("gas", "0x76c0");
+    parameters.put("gasPrice", "0x9184e72a000");
+    parameters.put("value", "0x9184e72a");
+    parameters.put(
+        "data",
+        "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675");
+
+    final JsonObject input = new JsonObject();
+    input.put("jsonrpc", 2.0);
+    input.put("method", "mine");
+    input.put("params", parameters);
+
+    final JsonRpcRequest request = input.mapTo(JsonRpcRequest.class);
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> EeaSendTransactionJsonParameters.from(request));
+  }
+}

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/RequestMapperTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/jsonrpcproxy/RequestMapperTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import tech.pegasys.ethsigner.core.http.RequestMapper;
 import tech.pegasys.ethsigner.core.requesthandler.JsonRpcRequestHandler;
 
-import com.google.common.collect.ImmutableMap;
-import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -45,9 +43,5 @@ public class RequestMapperTest {
     final RequestMapper requestMapper = new RequestMapper(defaultHandler);
     assertThat(requestMapper.getMatchingHandler("")).isEqualTo(defaultHandler);
     assertThat(requestMapper.getMatchingHandler("nothing")).isEqualTo(defaultHandler);
-  }
-
-  private JsonObject rpcJson(final String methodName) {
-    return new JsonObject(ImmutableMap.of("method", methodName));
   }
 }


### PR DESCRIPTION
Reject transactions sent using eea_sendTransaction with a non-zero value as private transactions doing a value transfer are not supported.