### PR TITLE
Change command line to use milliseconds instead of seconds

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerProcessRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerProcessRunner.java
@@ -56,7 +56,7 @@ public class EthSignerProcessRunner {
   private final Properties portsProperties;
   private final String nodeHostname;
   private final String nodeHttpRpcPort;
-  private final String timeoutSeconds;
+  private final String timeoutMilliseconds;
   private final String signerHostname;
   private final String chainId;
   private final boolean useDynamicPortAllocation;
@@ -72,7 +72,7 @@ public class EthSignerProcessRunner {
 
     this.nodeHostname = nodeConfig.getHostname();
     this.nodeHttpRpcPort = String.valueOf(nodePorts.getHttpRpc());
-    this.timeoutSeconds = String.valueOf(signerConfig.timeout().getSeconds());
+    this.timeoutMilliseconds = String.valueOf(signerConfig.timeout().toMillis());
     this.signerHostname = signerConfig.hostname();
     this.signerHttpRpcPort = signerConfig.httpRpcPort();
     this.chainId = signerConfig.chainId();
@@ -128,7 +128,7 @@ public class EthSignerProcessRunner {
     params.add("--downstream-http-port");
     params.add(nodeHttpRpcPort);
     params.add("--downstream-http-request-timeout");
-    params.add(timeoutSeconds);
+    params.add(timeoutMilliseconds);
     params.add("--http-listen-host");
     params.add(signerHostname);
     params.add("--http-listen-port");

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -66,9 +66,10 @@ public class EthSignerBaseCommand implements Config {
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"--downstream-http-request-timeout"},
-      description = "Timeout in seconds to wait for downstream request (default: ${DEFAULT-VALUE})",
+      description =
+          "Timeout in milliseconds to wait for downstream request (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private long downstreamHttpRequestTimeout = Duration.ofSeconds(5).getSeconds();
+  private long downstreamHttpRequestTimeout = Duration.ofSeconds(5).toMillis();
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
@@ -134,7 +135,7 @@ public class EthSignerBaseCommand implements Config {
 
   @Override
   public Duration getDownstreamHttpRequestTimeout() {
-    return Duration.ofSeconds(downstreamHttpRequestTimeout);
+    return Duration.ofMillis(downstreamHttpRequestTimeout);
   }
 
   @Override

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -58,7 +58,7 @@ public class CommandlineParserTest {
   private String parentCommandOptionsOnly() {
     return "--downstream-http-host=8.8.8.8 "
         + "--downstream-http-port=5000 "
-        + "--downstream-http-request-timeout=10 "
+        + "--downstream-http-request-timeout=10000 "
         + "--http-listen-port=5001 "
         + "--http-listen-host=localhost "
         + "--chain-id=6 "

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -61,7 +61,6 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
 import org.mockserver.model.RegexBody;
-import org.web3j.crypto.CipherException;
 import org.web3j.protocol.Web3j;
 import org.web3j.protocol.core.JsonRpc2_0Web3j;
 import org.web3j.protocol.eea.Eea;
@@ -90,11 +89,11 @@ public class IntegrationTestBase {
   protected static Duration downstreamTimeout = Duration.ofSeconds(1);
 
   @BeforeClass
-  public static void setupEthSigner() throws IOException, CipherException {
+  public static void setupEthSigner() throws IOException {
     setupEthSigner(DEFAULT_CHAIN_ID);
   }
 
-  protected static void setupEthSigner(final long chainId) throws IOException, CipherException {
+  protected static void setupEthSigner(final long chainId) throws IOException {
     clientAndServer = startClientAndServer();
 
     final TransactionSerialiser serialiser =
@@ -139,7 +138,7 @@ public class IntegrationTestBase {
     unlockedAccount = serialiser.getAddress();
   }
 
-  protected static void resetEthSigner() throws IOException, CipherException {
+  protected static void resetEthSigner() throws IOException {
     setupEthSigner();
   }
 

--- a/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSignerFactory.java
+++ b/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSignerFactory.java
@@ -50,7 +50,7 @@ public class HashicorpSignerFactory {
       final int serverPort,
       final String serverHost,
       final Path authFilePath,
-      final int timeout) {
+      final long timeout) {
     final String response =
         requestSecretFromVault(signingKeyPath, serverPort, serverHost, authFilePath, timeout);
     final Credentials credentials = extractCredentialsFromJson(response);
@@ -65,7 +65,7 @@ public class HashicorpSignerFactory {
       final int serverPort,
       final String serverHost,
       final Path authFilePath,
-      final int timeout) {
+      final long timeout) {
     final String requestURI = HASHICORP_SECRET_ENGINE_VERSION + signingKeyPath;
 
     return getVaultResponse(serverPort, serverHost, authFilePath, requestURI, timeout);
@@ -76,7 +76,7 @@ public class HashicorpSignerFactory {
       final String serverHost,
       final Path authFilePath,
       final String requestURI,
-      final int timeout) {
+      final long timeout) {
     final Vertx vertx = Vertx.vertx();
     try {
       final HttpClient httpClient = vertx.createHttpClient();
@@ -123,7 +123,7 @@ public class HashicorpSignerFactory {
     return authFileLines.get(0);
   }
 
-  private static String getResponse(final CompletableFuture<String> future, final int timeout) {
+  private static String getResponse(final CompletableFuture<String> future, final long timeout) {
     final String response;
     try {
       response = future.get(timeout, TimeUnit.SECONDS);

--- a/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSubCommand.java
+++ b/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSubCommand.java
@@ -16,6 +16,7 @@ import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.core.signing.TransactionSigner;
 
 import java.nio.file.Path;
+import java.time.Duration;
 
 import com.google.common.base.MoreObjects;
 import picocli.CommandLine.Command;
@@ -34,31 +35,27 @@ public class HashicorpSubCommand extends SignerSubCommand {
   private static final String DEFAULT_KEY_PATH = "/secret/data/ethsignerSigningKey";
   private static final String DEFAULT_PORT_STRING = "8200";
   private static final Integer DEFAULT_PORT = Integer.valueOf(DEFAULT_PORT_STRING);
-  private static final String DEFAULT_TIMEOUT_STRING = "10";
-  private static final Integer DEFAULT_TIMEOUT = Integer.valueOf(DEFAULT_TIMEOUT_STRING);
+  private static final Long DEFAULT_TIMEOUT = Duration.ofSeconds(10).toMillis();
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
       names = {"--host"},
       description = "Host of the Hashicorp vault server (default: ${DEFAULT-VALUE})",
-      defaultValue = DEFAULT_HASHICORP_VAULT_HOST,
       arity = "1")
   private String serverHost = DEFAULT_HASHICORP_VAULT_HOST;
 
   @Option(
       names = {"--port"},
       description = "Port of the Hashicorp vault server (default: ${DEFAULT-VALUE})",
-      defaultValue = DEFAULT_PORT_STRING,
       arity = "1")
   private final Integer serverPort = DEFAULT_PORT;
 
   @Option(
       names = {"--timeout"},
       description =
-          "Timeout in seconds for requests to the Hashicorp vault server (default: ${DEFAULT-VALUE})",
-      defaultValue = DEFAULT_TIMEOUT_STRING,
+          "Timeout in milliseconds for requests to the Hashicorp vault server (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Integer timeout = DEFAULT_TIMEOUT;
+  private final Long timeout = DEFAULT_TIMEOUT;
 
   @Option(
       names = {"--auth-file"},
@@ -73,7 +70,6 @@ public class HashicorpSubCommand extends SignerSubCommand {
       description =
           "Path to a secret in the Hashicorp vault containing the private key used for signing transactions. The "
               + "key needs to be a base 64 encoded private key for ECDSA for curve secp256k1 (default: ${DEFAULT-VALUE})",
-      defaultValue = DEFAULT_KEY_PATH,
       arity = "1")
   private String signingKeyPath = DEFAULT_KEY_PATH;
 


### PR DESCRIPTION
This changes the Ethsigner command line to use milliseconds instead of seconds