### PR TITLE
Azure tests

### DIFF
--- a/Jenkinsfile.azure
+++ b/Jenkinsfile.azure
@@ -1,0 +1,78 @@
+#!/usr/bin/env groovy
+
+import hudson.model.Result
+import hudson.model.Run
+import jenkins.model.CauseOfInterruption.UserInterruption
+
+if (env.BRANCH_NAME == "master") {
+    properties([
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: '90'
+            )
+        )
+    ])
+} else {
+    properties([
+        buildDiscarder(
+            logRotator(
+                numToKeepStr: '10'
+            )
+        )
+    ])
+}
+
+def abortPreviousBuilds() {
+    Run previousBuild = currentBuild.rawBuild.getPreviousBuildInProgress()
+
+    while (previousBuild != null) {
+        if (previousBuild.isInProgress()) {
+            def executor = previousBuild.getExecutor()
+            if (executor != null) {
+                echo ">> Aborting older build #${previousBuild.number}"
+                executor.interrupt(Result.ABORTED, new UserInterruption(
+                    "Aborted by newer build #${currentBuild.number}"
+                ))
+            }
+        }
+
+        previousBuild = previousBuild.getPreviousBuildInProgress()
+    }
+}
+
+if (env.BRANCH_NAME != "master") {
+    abortPreviousBuilds()
+}
+
+try {
+    node {
+        checkout scm
+        docker.image('docker:18.06.3-ce-dind').withRun('--privileged -v /volumes/jenkins-slave-workspace:/var/jenkins-slave-workspace') { d ->
+            docker.image('openjdk:11-jdk-stretch').inside("-e DOCKER_HOST=tcp://docker:2375 --link ${d.id}:docker") {
+                withCredentials([
+                    usernamePassword(
+                        credentialsId: 'ethsigner-azure',
+                        usernameVariable: 'ETHSIGNER_AZURE_CLIENT_ID',
+                        passwordVariable: 'ETHSIGNER_AZURE_CLIENT_SECRET'
+                    )
+                ]) {
+                    try {
+                        stage('Azure Test') {
+                            sh './gradlew --no-daemon --parallel :ethsigner:signer:azure:test'
+                        }
+                        stage('Azure Acceptance Test') {
+                            sh './gradlew --no-daemon --parallel acceptanceTest --tests *Azure*'
+                        }
+                    } finally {
+                        archiveArtifacts '**/build/reports/**'
+                        archiveArtifacts '**/build/test-results/**'
+
+                        junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
+                    }
+                }
+            }
+        }
+    }
+} catch (e) {
+    currentBuild.result = 'FAILURE'
+}

--- a/Jenkinsfile.azure
+++ b/Jenkinsfile.azure
@@ -57,10 +57,10 @@ try {
                     )
                 ]) {
                     try {
-                        stage('Azure Test') {
+                        stage('Test') {
                             sh './gradlew --no-daemon --parallel :ethsigner:signer:azure:test'
                         }
-                        stage('Azure Acceptance Test') {
+                        stage('Acceptance Test') {
                             sh './gradlew --no-daemon --parallel acceptanceTest --tests *Azure*'
                         }
                     } finally {

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/ValueTransferWithAzureAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/ValueTransferWithAzureAcceptanceTest.java
@@ -29,13 +29,12 @@ import tech.pegasys.ethsigner.tests.dsl.signer.SignerConfigurationBuilder;
 import java.math.BigInteger;
 
 import com.github.dockerjava.api.DockerClient;
+import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.utils.Convert;
 
-@Ignore
 public class ValueTransferWithAzureAcceptanceTest {
 
   private static final String RECIPIENT = "0x1b00ba00ca00bb00aa00bc00be00ac00ca00da00";
@@ -45,6 +44,10 @@ public class ValueTransferWithAzureAcceptanceTest {
 
   @BeforeClass
   public static void setUpBase() {
+    Assume.assumeTrue(
+        "Ensure Azure client id and client secret env variables are set",
+        System.getenv("ETHSIGNER_AZURE_CLIENT_ID") != null
+            && System.getenv("ETHSIGNER_AZURE_CLIENT_SECRET") != null);
 
     final DockerClient docker = new DockerClientFactory().create();
     final NodeConfiguration nodeConfig = new NodeConfigurationBuilder().build();

--- a/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
+++ b/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
@@ -150,7 +150,7 @@ public class AzureKeyVaultAuthenticatorTest {
 
     assertThatThrownBy(() -> factoryWithInvalidClientId.createSigner("TestKey", validKeyVersion))
         .isInstanceOf(TransactionSignerInitializationException.class)
-        .hasMessage(AzureKeyVaultTransactionSignerFactory.INACCESSIBLE_KEY_ERROR);
+        .hasMessage(AzureKeyVaultTransactionSignerFactory.UNKNOWN_VAULT_ACCESS_ERROR);
 
     final KeyVaultClientCustom clientWithInvalidSecret =
         authenticator.getAuthenticatedClient(clientId, "invalid_secret");

--- a/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
+++ b/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
@@ -29,13 +29,13 @@ import com.microsoft.azure.keyvault.models.KeyBundle;
 import com.microsoft.azure.keyvault.models.KeyItem;
 import com.microsoft.azure.keyvault.webkey.JsonWebKeyType;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Ignore;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.web3j.crypto.ECDSASignature;
 import org.web3j.crypto.Hash;
 import org.web3j.crypto.Sign;
 
-@Ignore
 public class AzureKeyVaultAuthenticatorTest {
 
   private static final String clientId = System.getenv("ETHSIGNER_AZURE_CLIENT_ID");
@@ -44,8 +44,15 @@ public class AzureKeyVaultAuthenticatorTest {
   private static final String validKeyVersion = "7c01fe58d68148bba5824ce418241092";
 
   private final AzureKeyVaultAuthenticator authenticator = new AzureKeyVaultAuthenticator();
-  private final KeyVaultClientCustom client =
-      authenticator.getAuthenticatedClient(clientId, clientSecret);
+  private KeyVaultClientCustom client;
+
+  @Before
+  public void checkAzureEnvSetup() {
+    Assume.assumeTrue(
+        "Ensure Azure client id and client secret env variables are set",
+        clientId != null && clientSecret != null);
+    client = authenticator.getAuthenticatedClient(clientId, clientSecret);
+  }
 
   @Test
   public void ensureCanAuthenticateAndFindKeys() {

--- a/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
+++ b/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
@@ -30,7 +30,7 @@ import com.microsoft.azure.keyvault.models.KeyItem;
 import com.microsoft.azure.keyvault.webkey.JsonWebKeyType;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.Assume;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.web3j.crypto.ECDSASignature;
 import org.web3j.crypto.Hash;
@@ -44,14 +44,14 @@ public class AzureKeyVaultAuthenticatorTest {
   private static final String validKeyVersion = "7c01fe58d68148bba5824ce418241092";
 
   private final AzureKeyVaultAuthenticator authenticator = new AzureKeyVaultAuthenticator();
-  private KeyVaultClientCustom client;
+  private final KeyVaultClientCustom client =
+      authenticator.getAuthenticatedClient(clientId, clientSecret);
 
-  @Before
-  public void checkAzureEnvSetup() {
+  @BeforeClass
+  public static void setup() {
     Assume.assumeTrue(
         "Ensure Azure client id and client secret env variables are set",
         clientId != null && clientSecret != null);
-    client = authenticator.getAuthenticatedClient(clientId, clientSecret);
   }
 
   @Test

--- a/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
+++ b/ethsigner/signer/azure/src/test/java/tech/pegasys/ethsigner/signer/azure/AzureKeyVaultAuthenticatorTest.java
@@ -160,7 +160,7 @@ public class AzureKeyVaultAuthenticatorTest {
     assertThatThrownBy(
             () -> factoryWithInvalidClientSecret.createSigner("TestKey", validKeyVersion))
         .isInstanceOf(TransactionSignerInitializationException.class)
-        .hasMessage(AzureKeyVaultTransactionSignerFactory.INACCESSIBLE_KEY_ERROR);
+        .hasMessage(AzureKeyVaultTransactionSignerFactory.UNKNOWN_VAULT_ACCESS_ERROR);
   }
 
   @Test


### PR DESCRIPTION
Setup seperate Jenkins job for the Azure tests so that the credentials can be used through environment variables.
Also 
* Changed the existing Azure tests to have a precondition on the environment variables set, so they can be used in the case we actually have the values set without removing the @ignore.
* Fixed the AzureKeyVaultAuthenticatorTest so that is checking the correct error message