### PR TITLE
Privacy group removes duplicates correctly

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtils.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtils.java
@@ -37,9 +37,10 @@ public class EeaUtils {
 
     final List<RlpType> rlpList =
         identifierList.stream()
-            .distinct()
             .sorted(Comparator.comparing(Arrays::hashCode))
             .map(RlpString::create)
+            .distinct() // do this last so we have an Object to the comparison on. Otherwise default
+            // equals will be used on a byte array which doesn't work
             .collect(Collectors.toList());
 
     final byte[] hash = Hash.sha3(RlpEncoder.encode(new RlpList(rlpList)));

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtils.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtils.java
@@ -31,16 +31,16 @@ public class EeaUtils {
   // Taken from web3j EeaTransactionManager as method is private in that class
   public static String generatePrivacyGroupId(
       final PrivacyIdentifier privateFrom, final List<PrivacyIdentifier> privateFor) {
-    final List<byte[]> identifierList = new ArrayList<>();
-    identifierList.add(privateFrom.getRaw());
-    privateFor.forEach(item -> identifierList.add(item.getRaw()));
+    final List<PrivacyIdentifier> identifierList = new ArrayList<>();
+    identifierList.add(privateFrom);
+    identifierList.addAll(privateFor);
 
     final List<RlpType> rlpList =
         identifierList.stream()
+            .distinct()
+            .map(PrivacyIdentifier::getRaw)
             .sorted(Comparator.comparing(Arrays::hashCode))
             .map(RlpString::create)
-            .distinct() // do this last so we have an Object to the comparison on. Otherwise default
-            // equals will be used on a byte array which doesn't work
             .collect(Collectors.toList());
 
     final byte[] hash = Hash.sha3(RlpEncoder.encode(new RlpList(rlpList)));

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtilsTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtilsTest.java
@@ -12,23 +12,22 @@
  */
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 class EeaUtilsTest {
 
   @Test
-  void createsPrivacyGroupIdWithSameFromAndTo() {
-    final PrivacyIdentifier sender =
+  void createsPrivacyGroupIdWithSamePrivateFromAndPrivateFor() {
+    final PrivacyIdentifier privateFrom =
         PrivacyIdentifier.fromBase64String("negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=");
-    final PrivacyIdentifier to =
+    final PrivacyIdentifier privateFor =
         PrivacyIdentifier.fromBase64String("negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=");
 
     final String privacyGroupId =
-        EeaUtils.generatePrivacyGroupId(sender, Collections.singletonList(to));
+        EeaUtils.generatePrivacyGroupId(privateFrom, singletonList(privateFor));
     assertThat(privacyGroupId).isEqualTo("kAbelwaVW7okoEn1+okO+AbA4Hhz/7DaCOWVQz9nx5M=");
   }
 }

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtilsTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EeaUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+class EeaUtilsTest {
+
+  @Test
+  void createsPrivacyGroupIdWithSameFromAndTo() {
+    final PrivacyIdentifier sender =
+        PrivacyIdentifier.fromBase64String("negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=");
+    final PrivacyIdentifier to =
+        PrivacyIdentifier.fromBase64String("negmDcN2P4ODpqn/6WkJ02zT/0w0bjhGpkZ8UP6vARk=");
+
+    final String privacyGroupId =
+        EeaUtils.generatePrivacyGroupId(sender, Collections.singletonList(to));
+    assertThat(privacyGroupId).isEqualTo("kAbelwaVW7okoEn1+okO+AbA4Hhz/7DaCOWVQz9nx5M=");
+  }
+}


### PR DESCRIPTION
Fix generation of the privacy group so that duplicate public keys are removed when determining the privacy group id. Without this change we get a different privacy group id to what Orion calculates.