### PR TITLE
Fixing the docker tags for releases

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -68,10 +68,10 @@ node {
                 script {
                     def docker_folder = 'docker'
                     def reports_folder = docker_folder + '/reports'
-                    def ethsigner = "pegasyseng/ethsigner:develop"
+                    def ethsigner = "pegasyseng/ethsigner:" + releaseVersion
                     def releaseVersion = "${params.RELEASE_VERSION.trim()}"
                     def shortReleaseVersion = getShortVersion(releaseVersion)
-                    def additionalTags = [releaseVersion]
+                    def additionalTags = []
 
                     stage(stage_name + 'Build image') {
                         sh "echo Building docker image for release ${releaseVersion} with short version ${shortReleaseVersion}"
@@ -101,6 +101,7 @@ node {
                                     additionalTags.add(shortReleaseVersion)
                                 }
                             }
+                            additionalTags.add('develop')
 
                             additionalTags.each { tag ->
                                 dockerImage.push tag.trim()

--- a/build.gradle
+++ b/build.gradle
@@ -460,10 +460,9 @@ tasks.register("dockerDistUntar") {
 task distDocker(type: Exec) {
   dependsOn dockerDistUntar
   def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
-  def image="pegasyseng/ethsigner:develop"
+  def image = project.hasProperty('release.releaseVersion') ? "pegasyseng/ethsigner:" + project.property('release.releaseVersion') : "pegasyseng/ethsigner:develop"
   def dockerBuildDir = "build/docker-ethsigner/"
   workingDir "${dockerBuildDir}"
-
 
   doFirst {
     copy {


### PR DESCRIPTION
Use the release_version as the base tag for releases, then add 'latest' and 'develop'