### PR TITLE
ES-52: Log request failures as debug (not error)

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/http/LogErrorHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/http/LogErrorHandler.java
@@ -26,7 +26,7 @@ public class LogErrorHandler implements Handler<RoutingContext> {
   public void handle(final RoutingContext failureContext) {
 
     if (failureContext.failed()) {
-      LOG.error(
+      LOG.debug(
           String.format("Failed request: %s", failureContext.request().absoluteURI()),
           failureContext.failure());
       // Let the next matching route or error handler deal with the error, we only handle logging


### PR DESCRIPTION
Using a locked account results in an "error" being added to the Ethsigner logs.
This is actually handled by the LogErrorHandler (invoked when a context fails) - thus all failed requests will now be logged as a debug.