### PR TITLE
Use junit5 for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,6 +342,8 @@ subprojects {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
     outputs.upToDateWhen { false }
+
+    useJUnitPlatform()
   }
 
   if (file('src/jmh').directory) {

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -52,9 +52,13 @@ dependencies {
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
   integrationTestImplementation project(':ethsigner:signer:file-based')
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'io.rest-assured:rest-assured'
   integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.mock-server:mockserver-netty'
+  integrationTestImplementation('org.mock-server:mockserver-netty') {
+    // mock-server includes a dependency on junit 4 for a junit rule which we aren't using
+    exclude group: 'junit', module: 'junit'
+  }
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -61,4 +61,6 @@ dependencies {
   }
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
+
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsIntegrationTest.java
@@ -21,14 +21,14 @@ import java.util.Map;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.json.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthAccounts;
 
-public class EthAccountsIntegrationTest extends IntegrationTestBase {
+class EthAccountsIntegrationTest extends IntegrationTestBase {
 
   @Test
-  public void ethAccountsRequestFromWeb3jRespondsWithNodesAddress() {
+  void ethAccountsRequestFromWeb3jRespondsWithNodesAddress() {
 
     final Request<?, EthAccounts> requestBody = jsonRpc().ethAccounts();
     final Map<String, String> expectedHeaders =

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthSignerParsingIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthSignerParsingIntegrationTest.java
@@ -14,14 +14,14 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.PARSE_ERROR;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EthSignerParsingIntegrationTest extends IntegrationTestBase {
+class EthSignerParsingIntegrationTest extends IntegrationTestBase {
 
   private static final Object NO_ID = null;
 
   @Test
-  public void parseErrorResponseWhenJsonRequestIsMalformed() {
+  void parseErrorResponseWhenJsonRequestIsMalformed() {
     sendRequestThenVerifyResponse(
         request.ethSigner(MALFORMED_JSON), response.ethSigner(NO_ID, PARSE_ERROR));
   }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/FailedConnectionTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/FailedConnectionTest.java
@@ -18,12 +18,12 @@ import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.EthProtocolVersionReque
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FailedConnectionTest extends IntegrationTestBase {
+class FailedConnectionTest extends IntegrationTestBase {
 
   @Test
-  public void failsToConnectToDownStreamRaisesTimeout() {
+  void failsToConnectToDownStreamRaisesTimeout() {
     clientAndServer.stop();
     final EthProtocolVersionRequest request = new EthProtocolVersionRequest(jsonRpc());
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -54,11 +54,10 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.Delay;
 import org.mockserver.model.Header;
 import org.mockserver.model.RegexBody;
 import org.web3j.protocol.Web3j;
@@ -74,10 +73,10 @@ public class IntegrationTestBase {
   private static final String LOCALHOST = "127.0.0.1";
   private static final long DEFAULT_CHAIN_ID = 9;
 
-  protected static final String MALFORMED_JSON = "{Bad Json: {{{}";
+  static final String MALFORMED_JSON = "{Bad Json: {{{}";
 
   private static Runner runner;
-  protected static ClientAndServer clientAndServer;
+  static ClientAndServer clientAndServer;
 
   private JsonRpc2_0Web3j jsonRpc;
   private JsonRpc2_0Eea eeaJsonRpc;
@@ -85,16 +84,16 @@ public class IntegrationTestBase {
   protected final EthRequestFactory request = new EthRequestFactory();
   protected final EthResponseFactory response = new EthResponseFactory();
 
-  protected static String unlockedAccount;
+  static String unlockedAccount;
 
-  protected static Duration downstreamTimeout = Duration.ofSeconds(1);
+  private static final Duration downstreamTimeout = Duration.ofSeconds(1);
 
-  @BeforeClass
+  @BeforeAll
   public static void setupEthSigner() throws IOException {
     setupEthSigner(DEFAULT_CHAIN_ID);
   }
 
-  protected static void setupEthSigner(final long chainId) throws IOException {
+  static void setupEthSigner(final long chainId) throws IOException {
     clientAndServer = startClientAndServer();
 
     final TransactionSignerProvider transactionSignerProvider =
@@ -140,19 +139,19 @@ public class IntegrationTestBase {
         transactionSignerProvider.availableAddresses().stream().findAny().orElseThrow();
   }
 
-  protected static void resetEthSigner() throws IOException {
+  static void resetEthSigner() throws IOException {
     setupEthSigner();
   }
 
-  protected Web3j jsonRpc() {
+  Web3j jsonRpc() {
     return jsonRpc;
   }
 
-  protected Eea eeaJsonRpc() {
+  Eea eeaJsonRpc() {
     return eeaJsonRpc;
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     jsonRpc = new JsonRpc2_0Web3j(null, 2000, defaultExecutorService());
     eeaJsonRpc = new JsonRpc2_0Eea(null);
@@ -161,13 +160,13 @@ public class IntegrationTestBase {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     clientAndServer.stop();
     runner.stop();
   }
 
-  public void setUpEthNodeResponse(final EthNodeRequest request, final EthNodeResponse response) {
+  void setUpEthNodeResponse(final EthNodeRequest request, final EthNodeResponse response) {
     final List<Header> headers = convertHeadersToMockServerHeaders(response.getHeaders());
     clientAndServer
         .when(request().withBody(json(request.getBody())), exactly(1))
@@ -178,7 +177,7 @@ public class IntegrationTestBase {
                 .withStatusCode(response.getStatusCode()));
   }
 
-  public void setupEthNodeResponse(
+  void setupEthNodeResponse(
       final String bodyRegex, final EthNodeResponse response, final int count) {
     final List<Header> headers = convertHeadersToMockServerHeaders(response.getHeaders());
     clientAndServer
@@ -190,7 +189,7 @@ public class IntegrationTestBase {
                 .withStatusCode(response.getStatusCode()));
   }
 
-  public void timeoutRequest(final String bodyRegex) {
+  void timeoutRequest(final String bodyRegex) {
     final int ENSURE_TIMEOUT = 5;
     clientAndServer
         .when(request().withBody(new RegexBody(bodyRegex)))
@@ -199,7 +198,7 @@ public class IntegrationTestBase {
                 .withDelay(TimeUnit.MILLISECONDS, downstreamTimeout.toMillis() + ENSURE_TIMEOUT));
   }
 
-  public void timeoutRequest(final EthNodeRequest request) {
+  void timeoutRequest(final EthNodeRequest request) {
     final int ENSURE_TIMEOUT = 5;
     clientAndServer
         .when(request().withBody(json(request.getBody())), exactly(1))
@@ -208,20 +207,7 @@ public class IntegrationTestBase {
                 .withDelay(TimeUnit.MILLISECONDS, downstreamTimeout.toMillis() + ENSURE_TIMEOUT));
   }
 
-  public void setUpEthNodeResponse(
-      final EthNodeRequest request, final EthNodeResponse response, final Delay delay) {
-    final List<Header> headers = convertHeadersToMockServerHeaders(response.getHeaders());
-    clientAndServer
-        .when(request().withBody(json(request.getBody())), exactly(1))
-        .respond(
-            response()
-                .withBody(response.getBody())
-                .withHeaders(headers)
-                .withStatusCode(response.getStatusCode())
-                .withDelay(delay));
-  }
-
-  public void sendRequestThenVerifyResponse(
+  void sendRequestThenVerifyResponse(
       final EthSignerRequest request, final EthSignerResponse expectResponse) {
     given()
         .when()
@@ -234,14 +220,14 @@ public class IntegrationTestBase {
         .headers(expectResponse.getHeaders());
   }
 
-  public void verifyEthNodeReceived(final String proxyBodyRequest) {
+  void verifyEthNodeReceived(final String proxyBodyRequest) {
     clientAndServer.verify(
         request()
             .withBody(proxyBodyRequest)
             .withHeaders(convertHeadersToMockServerHeaders(emptyMap())));
   }
 
-  public void verifyEthNodeReceived(
+  void verifyEthNodeReceived(
       final Map<String, String> proxyHeaders, final String proxyBodyRequest) {
     clientAndServer.verify(
         request()

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationIntegrationTest.java
@@ -17,14 +17,14 @@ import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.NetVersion;
 
-public class ProxyIntegrationIntegrationTest extends IntegrationTestBase {
+class ProxyIntegrationIntegrationTest extends IntegrationTestBase {
 
   @Test
-  public void requestWithHeadersIsProxied() {
+  void requestWithHeadersIsProxied() {
     final String netVersionRequest = Json.encode(jsonRpc().netVersion());
     final Response<String> netVersion = new NetVersion();
     netVersion.setResult("4");
@@ -42,7 +42,7 @@ public class ProxyIntegrationIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
-  public void requestReturningErrorIsProxied() {
+  void requestReturningErrorIsProxied() {
     final String ethProtocolVersionRequest = Json.encode(jsonRpc().ethProtocolVersion());
 
     setUpEthNodeResponse(

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEeaSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEeaSendTransactionIntegrationTest.java
@@ -23,18 +23,17 @@ import tech.pegasys.ethsigner.jsonrpcproxy.support.TransactionCountResponder;
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.web3j.crypto.CipherException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Signing is a step during proxying a sendTransaction() JSON-RPC request to an Ethereum node. */
-public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
+class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
   private EeaSendTransaction sendTransaction;
   private EeaSendRawTransaction sendRawTransaction;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     sendTransaction = new EeaSendTransaction();
     sendRawTransaction = new EeaSendRawTransaction(eeaJsonRpc());
     final TransactionCountResponder getTransactionResponse =
@@ -43,7 +42,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void proxyMalformedJsonResponseFromNode() {
+  void proxyMalformedJsonResponseFromNode() {
     final String rawTransaction = sendRawTransaction.request();
     setUpEthNodeResponse(request.ethNode(rawTransaction), response.ethNode(MALFORMED_JSON));
 
@@ -52,48 +51,48 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenNonceIsNaN() {
+  void invalidParamsResponseWhenNonceIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withNonce("I'm an invalid nonce format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsTooShort() {
+  void invalidParamsResponseWhenSenderAddressIsTooShort() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsTooLong() {
+  void invalidParamsResponseWhenSenderAddressIsTooLong() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x1577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
+  void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
+  void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0xb60e8dd61c5d32be8058bb8eb970870f07233XXX")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsWhenSenderAddressIsEmpty() {
+  void invalidParamsWhenSenderAddressIsEmpty() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("")), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenSenderAddressCaseMismatchesUnlockedAccount() {
+  void signTransactionWhenSenderAddressCaseMismatchesUnlockedAccount() {
     final String sendTransactionRequest =
         sendTransaction.withSender("0x7577919ae5df4941180eac211965f275CDCE314D");
     final String sendRawTransactionRequest =
@@ -112,26 +111,26 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenMissingSenderAddress() {
+  void invalidParamsResponseWhenMissingSenderAddress() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingSender()), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenReceiverAddressIsEmpty() {
+  void signTransactionWhenReceiverAddressIsEmpty() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withReceiver("")), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenReceiverAddressMissingHexPrefix() {
+  void invalidParamsResponseWhenReceiverAddressMissingHexPrefix() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withReceiver("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingReceiverAddress() {
+  void signTransactionWhenMissingReceiverAddress() {
     final String sendTransactionRequest = sendTransaction.missingReceiver();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -149,7 +148,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signTransactionWhenMissingValue() {
+  void signTransactionWhenMissingValue() {
     final String sendTransactionRequest = sendTransaction.missingValue();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -167,14 +166,14 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenValueIsNaN() {
+  void invalidParamsResponseWhenValueIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withValue("I'm an invalid value format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingGas() {
+  void signTransactionWhenMissingGas() {
     final String sendTransactionRequest = sendTransaction.missingGas();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -192,14 +191,14 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenGasIsNaN() {
+  void invalidParamsResponseWhenGasIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withGas("I'm an invalid gas format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingGasPrice() {
+  void signTransactionWhenMissingGasPrice() {
     final String sendTransactionRequest = sendTransaction.missingGasPrice();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -217,14 +216,14 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenGasPriceIsNaN() {
+  void invalidParamsResponseWhenGasPriceIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withGasPrice("I'm an invalid gas price format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signSendTransactionWhenMissingData() {
+  void signSendTransactionWhenMissingData() {
     final String sendTransactionRequest = sendTransaction.missingData();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -242,7 +241,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransactionWhenContract() {
+  void signSendTransactionWhenContract() {
     final String sendTransactionRequest = sendTransaction.smartContract();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -260,7 +259,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransactionWhenContractWithLongChainId() throws IOException, CipherException {
+  void signSendTransactionWhenContractWithLongChainId() throws IOException {
     setupEthSigner(4123123123L);
 
     final String sendTransactionRequest = sendTransaction.smartContract();
@@ -282,7 +281,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransaction() {
+  void signSendTransaction() {
     final String sendTransactionRequest = sendTransaction.request();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -300,7 +299,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void missingNonceInPrivateTransactionIsPopulated() {
+  void missingNonceInPrivateTransactionIsPopulated() {
     final String rawTransactionWithInitialNonce =
         sendRawTransaction.request(
             "0xf8dc018609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f0724456780a9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567536a039231358760e94952178f2963c32a977cbca58e9ebfbbd6263f8ca32b280516ea01d12666bea8dc7d4fb747c6dea691a7b90098c921e7f4adac8afd6178cbeb5a7a06656a912c97da832cfcbf7bcf3effacaf09411522f1fcdf2d0de00eb01ee2972e1a0195f26d1564071c60600060c06e610b4a123d17b695de6b0d803dca019ad036c8a72657374726963746564");
@@ -316,7 +315,7 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void transactionWithMissingNonceReturnsErrorsOtherThanLowNonceToCaller() {
+  void transactionWithMissingNonceReturnsErrorsOtherThanLowNonceToCaller() {
     final String rawTransactionWithInitialNonce =
         sendRawTransaction.request(
             "0xf8dc018609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f0724456780a9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567536a039231358760e94952178f2963c32a977cbca58e9ebfbbd6263f8ca32b280516ea01d12666bea8dc7d4fb747c6dea691a7b90098c921e7f4adac8afd6178cbeb5a7a06656a912c97da832cfcbf7bcf3effacaf09411522f1fcdf2d0de00eb01ee2972e1a0195f26d1564071c60600060c06e610b4a123d17b695de6b0d803dca019ad036c8a72657374726963746564");
@@ -329,20 +328,20 @@ public class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenMissingPrivateFrom() {
+  void invalidParamsResponseWhenMissingPrivateFrom() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingPrivateFrom()),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenMissingPrivateFor() {
+  void invalidParamsResponseWhenMissingPrivateFor() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingPrivateFor()), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenMissingRestriction() {
+  void invalidParamsResponseWhenMissingRestriction() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingRestriction()),
         response.ethSigner(INVALID_PARAMS));

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
@@ -27,18 +27,17 @@ import tech.pegasys.ethsigner.jsonrpcproxy.support.TransactionCountResponder;
 
 import java.io.IOException;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.web3j.crypto.CipherException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Signing is a step during proxying a sendTransaction() JSON-RPC request to an Ethereum node. */
-public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
+class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
   private SendTransaction sendTransaction;
   private SendRawTransaction sendRawTransaction;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     sendTransaction = new SendTransaction(jsonRpc());
     sendRawTransaction = new SendRawTransaction(jsonRpc());
     final TransactionCountResponder getTransactionResponse =
@@ -47,7 +46,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void proxyMalformedJsonResponseFromNode() {
+  void proxyMalformedJsonResponseFromNode() {
     final String rawTransaction = sendRawTransaction.request();
     setUpEthNodeResponse(request.ethNode(rawTransaction), response.ethNode(MALFORMED_JSON));
 
@@ -56,14 +55,14 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenNonceIsNaN() {
+  void invalidParamsResponseWhenNonceIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withNonce("I'm an invalid nonce format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void missingNonceResultsInEthNodeRespondingSuccessfully() {
+  void missingNonceResultsInEthNodeRespondingSuccessfully() {
     final String ethNodeResponseBody = "VALID_RESPONSE";
     final String requestBody =
         sendRawTransaction.request(
@@ -75,41 +74,41 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsTooShort() {
+  void invalidParamsResponseWhenSenderAddressIsTooShort() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsTooLong() {
+  void invalidParamsResponseWhenSenderAddressIsTooLong() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x1577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
+  void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
+  void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0xb60e8dd61c5d32be8058bb8eb970870f07233XXX")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
-  public void invalidParamsWhenSenderAddressIsEmpty() {
+  void invalidParamsWhenSenderAddressIsEmpty() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withSender("")), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenSenderAddressCaseMismatchesUnlockedAccount() {
+  void signTransactionWhenSenderAddressCaseMismatchesUnlockedAccount() {
     final String sendTransactionRequest =
         sendTransaction.withSender("0x7577919ae5df4941180eac211965f275CDCE314D");
     final String sendRawTransactionRequest =
@@ -128,26 +127,26 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenMissingSenderAddress() {
+  void invalidParamsResponseWhenMissingSenderAddress() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.missingSender()), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenReceiverAddressIsEmpty() {
+  void signTransactionWhenReceiverAddressIsEmpty() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withReceiver("")), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void invalidParamsResponseWhenReceiverAddressMissingHexPrefix() {
+  void invalidParamsResponseWhenReceiverAddressMissingHexPrefix() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withReceiver("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingReceiverAddress() {
+  void signTransactionWhenMissingReceiverAddress() {
     final String sendTransactionRequest = sendTransaction.missingReceiver();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -165,7 +164,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signTransactionWhenMissingValue() {
+  void signTransactionWhenMissingValue() {
     final String sendTransactionRequest = sendTransaction.missingValue();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -183,14 +182,14 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenValueIsNaN() {
+  void invalidParamsResponseWhenValueIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withValue("I'm an invalid value format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingGas() {
+  void signTransactionWhenMissingGas() {
     final String sendTransactionRequest = sendTransaction.missingGas();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -208,14 +207,14 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenGasIsNaN() {
+  void invalidParamsResponseWhenGasIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withGas("I'm an invalid gas format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signTransactionWhenMissingGasPrice() {
+  void signTransactionWhenMissingGasPrice() {
     final String sendTransactionRequest = sendTransaction.missingGasPrice();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -233,14 +232,14 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void invalidParamsResponseWhenGasPriceIsNaN() {
+  void invalidParamsResponseWhenGasPriceIsNaN() {
     sendRequestThenVerifyResponse(
         request.ethSigner(sendTransaction.withGasPrice("I'm an invalid gas price format!")),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
-  public void signSendTransactionWhenMissingData() {
+  void signSendTransactionWhenMissingData() {
     final String sendTransactionRequest = sendTransaction.missingData();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -258,7 +257,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransactionWhenContract() {
+  void signSendTransactionWhenContract() {
     final String sendTransactionRequest = sendTransaction.smartContract();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -276,7 +275,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransactionWhenContractWithLongChainId() throws IOException, CipherException {
+  void signSendTransactionWhenContractWithLongChainId() throws IOException {
     setupEthSigner(4123123123L);
 
     final String sendTransactionRequest = sendTransaction.smartContract();
@@ -298,7 +297,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void signSendTransaction() {
+  void signSendTransaction() {
     final String sendTransactionRequest = sendTransaction.request();
     final String sendRawTransactionRequest =
         sendRawTransaction.request(
@@ -316,7 +315,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void missingNonceResultsInNewNonceBeingCreatedAndResent() {
+  void missingNonceResultsInNewNonceBeingCreatedAndResent() {
     final String rawTransactionWithInitialNonce =
         sendRawTransaction.request(
             "0xf892808609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567536a0eab405b58d6aa7db96ebfab8c55825504090447d6209848eeca5a2a2ff909467a064712627fdf02027521a716b8e9a497d31f7c4d5ecb75840fde86ade1d726fab");
@@ -339,7 +338,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void transactionWithMissingNonceReturnsErrorsOtherThanLowNonceToCaller() {
+  void transactionWithMissingNonceReturnsErrorsOtherThanLowNonceToCaller() {
     final String rawTransactionWithInitialNonce =
         sendRawTransaction.request(
             "0xf892018609184e72a0008276c094d46e8dd67c5d32be8058bb8eb970870f07244567849184e72aa9d46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f07244567535a05b2b6e380da44241ecd30b21bd56f05da80e217a6347dfe06b0fb00b2e4adc14a048c4f0255bdb5526171b0a771e61b9f44b3c3fca2feffae04d1748297726ca0f");
@@ -352,7 +351,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void moreThanFiveNonceTooLowErrorsReturnsAnErrorToUser() {
+  void moreThanFiveNonceTooLowErrorsReturnsAnErrorToUser() {
     setupEthNodeResponse(".*eth_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 6);
 
     sendRequestThenVerifyResponse(
@@ -360,7 +359,7 @@ public class SigningEthSendTransactionIntegrationTest extends IntegrationTestBas
   }
 
   @Test
-  public void thirdNonceRetryTimesOutAndGatewayTimeoutIsReturnedToClient() {
+  void thirdNonceRetryTimesOutAndGatewayTimeoutIsReturnedToClient() {
     setupEthNodeResponse(".*eth_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 3);
     timeoutRequest(".*eth_sendRawTransaction.*");
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/TimeoutTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/TimeoutTest.java
@@ -18,12 +18,12 @@ import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.EthProtocolVersionReque
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TimeoutTest extends IntegrationTestBase {
+class TimeoutTest extends IntegrationTestBase {
 
   @Test
-  public void downstreamConnectsButDoesNotRespondReturnsGatewayTimeout() {
+  void downstreamConnectsButDoesNotRespondReturnsGatewayTimeout() {
     final EthProtocolVersionRequest request = new EthProtocolVersionRequest(jsonRpc());
 
     timeoutRequest(this.request.ethNode(request.getEncodedRequestBody()));

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -53,7 +53,7 @@ dependencyManagement {
 
     dependency 'org.awaitility:awaitility:3.1.6'
 
-    dependency 'org.mock-server:mockserver-netty:5.5.1'
+    dependency 'org.mock-server:mockserver-netty:5.7.0'
 
     dependency 'org.web3j:core:4.5.0'
     dependency 'org.web3j:crypto:4.5.0'


### PR DESCRIPTION
Use junit 5 for integration tests in EthSigner. With this change Ethsigner is now using Junit5 for all tests.