### PR TITLE
Using gradle root project build dir in check-license

### DIFF
--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -163,7 +163,7 @@ task checkLicenses {
 
   def bads = ""
   doLast {
-    def xml = new XmlParser().parse('${rootProject.buildDir}/reports/license/license-dependency.xml')
+    def xml = new XmlParser().parse("${rootProject.buildDir}/reports/license/license-dependency.xml")
     xml.each { license ->
       if (!acceptedLicenses.contains((license.@name).toLowerCase())) {
         def depStrings = []

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -163,7 +163,7 @@ task checkLicenses {
 
   def bads = ""
   doLast {
-    def xml = new XmlParser().parse('build/reports/license/license-dependency.xml')
+    def xml = new XmlParser().parse('${rootProject.buildDir}/reports/license/license-dependency.xml')
     xml.each { license ->
       if (!acceptedLicenses.contains((license.@name).toLowerCase())) {
         def depStrings = []


### PR DESCRIPTION
gradle reports incorrect `user.dir` in jdk12.0.2 (on Mac Catalina) resulting in check-license task to fail.
Fixing check-license to use root project's build dir property instead of relative path which resolves to `user.dir` solves the issue.