### PR TITLE
adding in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ executors:
     resource_class: large
     working_directory: ~/project
 
+  executor_machine:
+    machine:
+      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      docker_layer_caching: true
+    working_directory: ~/project
+
 commands:
   prepare:
     description: "Prepare"
@@ -32,7 +38,6 @@ commands:
             - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
             - deps-{{ checksum "build.gradle" }}
             - deps-
-
 
   capture_test_results:
     description: "Capture test results"
@@ -84,10 +89,7 @@ jobs:
             - ./
 
   acceptanceTests:
-    machine:
-      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
-      docker_layer_caching: true
-    working_directory: ~/project
+    executor: executor_machine
     steps:
       - prepare
       - run:
@@ -105,10 +107,7 @@ jobs:
       - capture_test_results
 
   azureTests:
-    machine:
-      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
-      docker_layer_caching: true
-    working_directory: ~/project
+    executor: executor_machine
     steps:
       - prepare
       - run:
@@ -140,6 +139,11 @@ jobs:
           name: build image
           command: |
             ./gradlew --no-daemon distDocker
+      - run:
+          name: test image
+          command: |
+            mkdir -p docker/reports
+            ./gradlew --no-daemon testDocker
 
   publish:
     executor: executor_med

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,205 @@
+---
+version: 2.1
+executors:
+  executor_med:  # 2cpu, 4G ram
+    docker:
+      - image: circleci/openjdk:11.0.4-jdk-stretch
+    resource_class: medium
+    working_directory: ~/project
+    environment:
+      JAVA_TOOL_OPTIONS: -Xmx2048m
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2 -Xmx2048m
+
+  executor_large: # 4cpu, 8G ram
+    docker:
+      - image: circleci/openjdk:11.0.4-jdk-stretch
+    resource_class: large
+    working_directory: ~/project
+
+commands:
+  prepare:
+    description: "Prepare"
+    steps:
+      - checkout
+      - run:
+          name: Install Packages - LibSodium
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libsodium18 libsodium-dev apt-transport-https
+      - restore_cache:
+          name: Restore cached gradle dependencies
+          keys:
+            - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            - deps-{{ checksum "build.gradle" }}
+            - deps-
+
+
+  capture_test_results:
+    description: "Capture test results"
+    steps:
+      - run:
+          name: Gather test results
+          when: always
+          command: |
+            FILES=`find . -name test-results`
+            for FILE in $FILES
+            do
+              MODULE=`echo "$FILE" | sed -e 's@./\(.*\)/build/test-results@\1@'`
+              TARGET="build/test-results/$MODULE"
+              mkdir -p "$TARGET"
+              cp -rf ${FILE}/*/* "$TARGET"
+            done
+      - store_test_results:
+          path: build/test-results
+
+jobs:
+  build:
+    executor: executor_large
+    steps:
+      - prepare
+      - run:
+          name: Build
+          command: |
+            ./gradlew --no-daemon --parallel build
+      - run:
+          name: Test
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel test
+      - run:
+          name: Integration Test
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel integrationTest --info
+      - capture_test_results
+      - save_cache:
+          name: Caching gradle dependencies
+          key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .gradle
+            - ~/.gradle
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ./
+
+  acceptanceTests:
+    machine:
+      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      docker_layer_caching: true
+    working_directory: ~/project
+    steps:
+      - prepare
+      - run:
+          name: Install Packages - Java 11
+          command: |
+            sudo add-apt-repository -y ppa:openjdk-r/ppa
+            sudo apt update
+            sudo apt install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+      - run:
+          name: Acceptance Test
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel acceptanceTest
+      - capture_test_results
+
+  azureTests:
+    machine:
+      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      docker_layer_caching: true
+    working_directory: ~/project
+    steps:
+      - prepare
+      - run:
+          name: Install Packages - Java 11
+          command: |
+            sudo add-apt-repository -y ppa:openjdk-r/ppa
+            sudo apt update
+            sudo apt install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+      - run:
+          name: Azure tests
+          command: |
+            ./gradlew --no-daemon --parallel :ethsigner:signer:azure:test
+            ./gradlew --no-daemon --parallel acceptanceTest --tests *Azure*
+      - capture_test_results
+
+  buildDocker:
+    executor: executor_med
+    steps:
+      - prepare
+      - setup_remote_docker
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: hadoLint
+          command: |
+            docker run --rm -i hadolint/hadolint < docker/Dockerfile
+      - run:
+          name: build image
+          command: |
+            ./gradlew --no-daemon distDocker
+
+  publish:
+    executor: executor_med
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Publish
+          command: |
+            ./gradlew --no-daemon --parallel bintrayUpload
+
+  publishDocker:
+    executor: executor_med
+    steps:
+      - prepare
+      - setup_remote_docker
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Publish Docker
+          command: |
+            docker login --username "${DOCKER_USER}" --password "${DOCKER_PASSWORD}"
+            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build
+      - acceptanceTests
+      - azureTests:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+          requires:
+            - build
+      - buildDocker:
+          requires:
+            - build
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+          requires:
+            - build
+            - acceptanceTests
+            - azureTests
+      - publishDocker:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+          requires:
+            - build
+            - acceptanceTests
+            - azureTests
+            - buildDocker

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,22 +80,9 @@ try {
                         // build image
                         sh './gradlew distDocker'
 
-                        // test image labels
-                        shortCommit = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
-                        version = sh(returnStdout: true, script: "grep -oE \"version=(.*)\" ${version_property_file} | cut -d= -f2").trim()
-                        sh "docker image inspect \
-    --format='{{index .Config.Labels \"org.label-schema.vcs-ref\"}}' \
-    ${image} \
-    | grep ${shortCommit}"
-                        sh "docker image inspect \
-    --format='{{index .Config.Labels \"org.label-schema.version\"}}' \
-    ${image} \
-    | grep ${version}"
-
                         // test image
                         try {
-                            sh "mkdir -p ${reports_folder}"
-                            sh "cd ${docker_folder} && bash test.sh ${image}"
+                            sh './gradlew testDocker'
                         } finally {
                             junit "${reports_folder}/*.xml"
                             sh "rm -rf ${reports_folder}"

--- a/build.gradle
+++ b/build.gradle
@@ -462,7 +462,8 @@ tasks.register("dockerDistUntar") {
 task distDocker(type: Exec) {
   dependsOn dockerDistUntar
   def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
-  def image = project.hasProperty('release.releaseVersion') ? "pegasyseng/ethsigner:" + project.property('release.releaseVersion') : "pegasyseng/ethsigner:develop"
+  def imageName = "pegasyseng/ethsigner"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
   def dockerBuildDir = "build/docker-ethsigner/"
   workingDir "${dockerBuildDir}"
 
@@ -475,6 +476,27 @@ task distDocker(type: Exec) {
 
   executable "sh"
   args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+}
+
+task dockerUpload(type: Exec) {
+  dependsOn distDocker
+  def imageName = "pegasyseng/ethsigner"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
+  def cmd = "docker push '${image}'"
+  def additionalTags = []
+
+  if (project.hasProperty('branch') && project.property('branch') == 'master') {
+    additionalTags.add('develop')
+  }
+
+  if (! version ==~ /.*-SNAPSHOT/) {
+    additionalTags.add('latest')
+    additionalTags.add(version.split(/\./)[0..1].join('.'))
+  }
+
+  additionalTags.each { tag -> cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'" }
+  executable "sh"
+  args "-c", cmd
 }
 
 task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {

--- a/build.gradle
+++ b/build.gradle
@@ -478,6 +478,21 @@ task distDocker(type: Exec) {
   args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
 }
 
+task testDocker(type: Exec) {
+  dependsOn distDocker
+  def dockerReportsDir = "docker/reports/"
+  def imageName = "pegasyseng/ethsigner"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
+  workingDir "docker"
+
+  doFirst {
+    new File(dockerReportsDir).mkdir()
+  }
+
+  executable "sh"
+  args "-c", "bash test.sh ${image}"
+}
+
 task dockerUpload(type: Exec) {
   dependsOn distDocker
   def imageName = "pegasyseng/ethsigner"


### PR DESCRIPTION
Adding in circleci config, this collates all the 3 jenkins jobs into 1 with :
- docker publish, bintray publish and azure tests only happening on master (so we dont send creds out on PR's)
- integrationTests seem to need the --info flag as well to run.

https://circleci.com/workflow-run/8864a054-ee81-443e-b353-781857614ff5



