### PR TITLE
Rename integration send request method

### DIFF
--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthAccountsIntegrationTest.java
@@ -37,7 +37,7 @@ class EthAccountsIntegrationTest extends IntegrationTestBase {
     final JsonRpcSuccessResponse responseBody =
         new JsonRpcSuccessResponse(requestBody.getId(), singletonList(unlockedAccount));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(Json.encode(requestBody)),
         response.ethSigner(expectedHeaders, Json.encode(responseBody)));
   }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthSignerParsingIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/EthSignerParsingIntegrationTest.java
@@ -22,6 +22,7 @@ class EthSignerParsingIntegrationTest extends IntegrationTestBase {
 
   @Test
   void parseErrorResponseWhenJsonRequestIsMalformed() {
-    sendPostRequest(request.ethSigner(MALFORMED_JSON), response.ethSigner(NO_ID, PARSE_ERROR));
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(MALFORMED_JSON), response.ethSigner(NO_ID, PARSE_ERROR));
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/FailedConnectionTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/FailedConnectionTest.java
@@ -32,7 +32,7 @@ class FailedConnectionTest extends IntegrationTestBase {
             new JsonRpcErrorResponse(
                 request.getId(), JsonRpcError.CONNECTION_TO_DOWNSTREAM_NODE_TIMED_OUT));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         this.request.ethSigner(request.getEncodedRequestBody()),
         response.ethSigner(expectedResponse, HttpResponseStatus.GATEWAY_TIMEOUT));
   }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -217,11 +217,12 @@ public class IntegrationTestBase {
                 .withDelay(TimeUnit.MILLISECONDS, downstreamTimeout.toMillis() + ENSURE_TIMEOUT));
   }
 
-  void sendPostRequest(final EthSignerRequest request, final EthSignerResponse expectResponse) {
-    sendPostRequest(request, expectResponse, "/");
+  void sendPostRequestAndVerifyResponse(
+      final EthSignerRequest request, final EthSignerResponse expectResponse) {
+    sendPostRequestAndVerifyResponse(request, expectResponse, "/");
   }
 
-  void sendPostRequest(
+  void sendPostRequestAndVerifyResponse(
       final EthSignerRequest request, final EthSignerResponse expectResponse, final String path) {
     given()
         .when()
@@ -234,7 +235,7 @@ public class IntegrationTestBase {
         .headers(expectResponse.getHeaders());
   }
 
-  void sendPutRequest(
+  void sendPutRequestAndVerifyResponse(
       final EthSignerRequest request, final EthSignerResponse expectResponse, final String path) {
     given()
         .when()
@@ -247,7 +248,7 @@ public class IntegrationTestBase {
         .headers(expectResponse.getHeaders());
   }
 
-  void sendGetRequest(
+  void sendGetRequestAndVerifyResponse(
       final EthSignerRequest request, final EthSignerResponse expectResponse, final String path) {
     given()
         .when()
@@ -260,7 +261,7 @@ public class IntegrationTestBase {
         .headers(expectResponse.getHeaders());
   }
 
-  void sendDeleteRequest(
+  void sendDeleteRequestAndVerifyResponse(
       final EthSignerRequest request, final EthSignerResponse expectResponse, final String path) {
     given()
         .when()

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -39,7 +39,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(REQUEST_HEADERS, netVersionRequest),
         response.ethSigner(RESPONSE_HEADERS, netVersionResponse));
 
@@ -54,7 +54,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(ethProtocolVersionRequest),
         response.ethNode("Not Found", HttpResponseStatus.NOT_FOUND));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(ethProtocolVersionRequest),
         response.ethSigner("Not Found", HttpResponseStatus.NOT_FOUND));
 
@@ -67,7 +67,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(LOGIN_BODY),
         response.ethNode(RESPONSE_HEADERS, LOGIN_RESPONSE, HttpResponseStatus.OK));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(REQUEST_HEADERS, LOGIN_BODY),
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
@@ -83,7 +83,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
 
     // Whilst a get request doesn't normally have a body, it can and we want to ensure the request
     // is proxied as is
-    sendGetRequest(
+    sendGetRequestAndVerifyResponse(
         request.ethSigner(REQUEST_HEADERS, LOGIN_BODY),
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
@@ -97,7 +97,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(LOGIN_BODY),
         response.ethNode(RESPONSE_HEADERS, LOGIN_RESPONSE, HttpResponseStatus.OK));
 
-    sendPutRequest(
+    sendPutRequestAndVerifyResponse(
         request.ethSigner(REQUEST_HEADERS, LOGIN_BODY),
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
@@ -111,7 +111,7 @@ class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(LOGIN_BODY),
         response.ethNode(RESPONSE_HEADERS, LOGIN_RESPONSE, HttpResponseStatus.OK));
 
-    sendDeleteRequest(
+    sendDeleteRequestAndVerifyResponse(
         request.ethSigner(REQUEST_HEADERS, LOGIN_BODY),
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEeaSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEeaSendTransactionIntegrationTest.java
@@ -57,12 +57,13 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     final String rawTransaction = sendRawTransaction.request();
     setUpEthNodeResponse(request.ethNode(rawTransaction), response.ethNode(MALFORMED_JSON));
 
-    sendPostRequest(request.ethSigner(rawTransaction), response.ethSigner(MALFORMED_JSON));
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(rawTransaction), response.ethSigner(MALFORMED_JSON));
   }
 
   @Test
   void invalidParamsResponseWhenNonceIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withNonce("I'm an invalid nonce format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -74,41 +75,41 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
     setUpEthNodeResponse(request.ethNode(requestBody), response.ethNode(ethNodeResponseBody));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(ethNodeResponseBody));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsTooShort() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsTooLong() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x1577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0xb60e8dd61c5d32be8058bb8eb970870f07233XXX")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsWhenSenderAddressIsEmpty() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("")), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -125,7 +126,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -133,7 +134,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenMissingSenderAddress() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingSender()), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -149,7 +150,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -167,7 +168,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -186,7 +187,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -203,7 +204,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -221,7 +222,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -238,7 +239,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -255,7 +256,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -263,7 +264,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenValueIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withValue("I'm an invalid value format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -280,7 +281,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -298,7 +299,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -306,7 +307,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenGasIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withGas("I'm an invalid gas format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -322,7 +323,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -340,7 +341,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -348,7 +349,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenGasPriceIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withGasPrice("I'm an invalid gas price format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -364,7 +365,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -380,7 +381,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -400,7 +401,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
         request.ethNode(rawTransactionWithNextNonce),
         response.ethNode(successResponseFromWeb3Provider));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()),
         response.ethSigner(successResponseFromWeb3Provider));
   }
@@ -419,7 +420,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
         request.ethNode(rawTransactionWithNextNonce),
         response.ethNode(successResponseFromWeb3Provider));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withNonce(null)),
         response.ethSigner(successResponseFromWeb3Provider));
   }
@@ -434,7 +435,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
         request.ethNode(rawTransactionWithInitialNonce),
         response.ethNode(successResponseFromWeb3Provider));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()),
         response.ethSigner(successResponseFromWeb3Provider));
   }
@@ -446,7 +447,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(rawTransactionWithInitialNonce), response.ethNode(INVALID_PARAMS));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -454,7 +455,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
   void moreThanFiveNonceTooLowErrorsReturnsAnErrorToUser() {
     setupEthNodeResponse(".*eea_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 6);
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(INTERNAL_ERROR));
   }
 
@@ -463,48 +464,48 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     setupEthNodeResponse(".*eea_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 3);
     timeoutRequest(".*eea_sendRawTransaction.*");
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()),
         response.ethSigner(CONNECTION_TO_DOWNSTREAM_NODE_TIMED_OUT, GATEWAY_TIMEOUT));
   }
 
   @Test
   void invalidParamsResponseWhenMissingPrivateFrom() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingPrivateFrom()),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
   void invalidParamsResponseWhenMissingPrivateFor() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingPrivateFor()), response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
   void invalidParamsResponseWhenPrivateForIsNull() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withPrivateFor(null)),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
   void invalidParamsResponseWhenMissingRestriction() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingRestriction()),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
   void invalidParamsResponseWhenRestrictionIsNull() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withRestriction(null)),
         response.ethSigner(INVALID_PARAMS));
   }
 
   @Test
   void invalidParamsResponseWhenRestrictionHasInvalidValue() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withRestriction("invalid")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -514,7 +515,7 @@ class SigningEeaSendTransactionIntegrationTest extends IntegrationTestBase {
     final String ethNodeResponseBody = "VALID_RESPONSE";
     final String requestBody = sendRawTransaction.request(sendTransaction.withNonce("0x1"));
     setUpEthNodeResponse(request.ethNode(requestBody), response.ethNode(ethNodeResponseBody));
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(ethNodeResponseBody));
     final String expectedBody =
         String.format(

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
@@ -54,12 +54,13 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     final String rawTransaction = sendRawTransaction.request();
     setUpEthNodeResponse(request.ethNode(rawTransaction), response.ethNode(MALFORMED_JSON));
 
-    sendPostRequest(request.ethSigner(rawTransaction), response.ethSigner(MALFORMED_JSON));
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(rawTransaction), response.ethSigner(MALFORMED_JSON));
   }
 
   @Test
   void invalidParamsResponseWhenNonceIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withNonce("I'm an invalid nonce format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -71,41 +72,41 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
     setUpEthNodeResponse(request.ethNode(requestBody), response.ethNode(ethNodeResponseBody));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(ethNodeResponseBody));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsTooShort() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsTooLong() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0x1577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressMissingHexPrefix() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("7577919ae5df4941180eac211965f275CDCE314D")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsResponseWhenSenderAddressIsMalformedHex() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("0xb60e8dd61c5d32be8058bb8eb970870f07233XXX")),
         response.ethSigner(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
   }
 
   @Test
   void invalidParamsWhenSenderAddressIsEmpty() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withSender("")), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -122,7 +123,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -130,7 +131,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenMissingSenderAddress() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingSender()), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -145,7 +146,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -163,7 +164,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -182,7 +183,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -199,7 +200,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -217,7 +218,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -234,7 +235,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -251,7 +252,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -259,7 +260,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenValueIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withValue("I'm an invalid value format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -276,7 +277,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -294,7 +295,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -302,7 +303,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenGasIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withGas("I'm an invalid gas format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -318,7 +319,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -336,7 +337,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -344,7 +345,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
 
   @Test
   void invalidParamsResponseWhenGasPriceIsNaN() {
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withGasPrice("I'm an invalid gas price format!")),
         response.ethSigner(INVALID_PARAMS));
   }
@@ -360,7 +361,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -377,7 +378,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -396,7 +397,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -414,7 +415,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(sendRawTransactionRequest), response.ethNode(sendRawTransactionResponse));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransactionRequest), response.ethSigner(sendRawTransactionResponse));
 
     verifyEthNodeReceived(sendRawTransactionRequest);
@@ -434,7 +435,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
         request.ethNode(rawTransactionWithNextNonce),
         response.ethNode(successResponseFromWeb3Provider));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()),
         response.ethSigner(successResponseFromWeb3Provider));
   }
@@ -453,7 +454,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
         request.ethNode(rawTransactionWithNextNonce),
         response.ethNode(successResponseFromWeb3Provider));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.withNonce(null)),
         response.ethSigner(successResponseFromWeb3Provider));
   }
@@ -465,7 +466,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setUpEthNodeResponse(
         request.ethNode(rawTransactionWithInitialNonce), response.ethNode(INVALID_PARAMS));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(INVALID_PARAMS));
   }
 
@@ -473,7 +474,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
   void moreThanFiveNonceTooLowErrorsReturnsAnErrorToUser() {
     setupEthNodeResponse(".*eth_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 6);
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()), response.ethSigner(INTERNAL_ERROR));
   }
 
@@ -482,7 +483,7 @@ class SigningEthSendTransactionIntegrationTest extends IntegrationTestBase {
     setupEthNodeResponse(".*eth_sendRawTransaction.*", response.ethNode(NONCE_TOO_LOW), 3);
     timeoutRequest(".*eth_sendRawTransaction.*");
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         request.ethSigner(sendTransaction.missingNonce()),
         response.ethSigner(CONNECTION_TO_DOWNSTREAM_NODE_TIMED_OUT, GATEWAY_TIMEOUT));
   }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/TimeoutTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/TimeoutTest.java
@@ -33,7 +33,7 @@ class TimeoutTest extends IntegrationTestBase {
             new JsonRpcErrorResponse(
                 request.getId(), JsonRpcError.CONNECTION_TO_DOWNSTREAM_NODE_TIMED_OUT));
 
-    sendPostRequest(
+    sendPostRequestAndVerifyResponse(
         this.request.ethSigner(request.getEncodedRequestBody()),
         response.ethSigner(expectedResponse, HttpResponseStatus.GATEWAY_TIMEOUT));
   }


### PR DESCRIPTION
Renames the integration test send request methods to more clearly show that they send a request and verify the response.