### PR TITLE
Change integration tests to use EthSigner port file

### DIFF
--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -61,6 +61,7 @@ dependencies {
   }
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
+  integrationTestImplementation 'org.awaitility:awaitility'
 
   integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -24,7 +24,6 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 import static org.web3j.utils.Async.defaultExecutorService;
 
-import java.net.ServerSocket;
 import tech.pegasys.ethsigner.core.Runner;
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.TransactionFactory;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -142,7 +142,7 @@ public class IntegrationTestBase {
             httpServerOptions,
             downstreamTimeout,
             new TransactionFactory(besu, web3j, web3jService),
-            null);
+            dataPath);
     runner.start();
 
     final int ethSignerPort = httpJsonRpcPort();

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -156,7 +156,9 @@ public class IntegrationTestBase {
             dataPath);
     runner.start();
 
-    final int ethSignerPort = httpJsonRpcPort();
+    final Path portsFile = dataPath.resolve(PORTS_FILENAME);
+    waitForNonEmptyFileToExist(portsFile);
+    final int ethSignerPort = httpJsonRpcPort(portsFile);
     RestAssured.port = ethSignerPort;
 
     LOG.info(
@@ -344,13 +346,8 @@ public class IntegrationTestBase {
     return file;
   }
 
-  private static int httpJsonRpcPort() {
-    final File portsFile = new File(dataPath.toFile(), PORTS_FILENAME);
-    LOG.info("Awaiting presence of ethsigner.ports file: {}", portsFile.getAbsolutePath());
-    awaitPortsFile(dataPath);
-    LOG.info("Found ethsigner.ports file: {}", portsFile.getAbsolutePath());
-
-    try (final FileInputStream fis = new FileInputStream(portsFile)) {
+  private static int httpJsonRpcPort(final Path portsFile) {
+    try (final FileInputStream fis = new FileInputStream(portsFile.toString())) {
       final Properties portProperties = new Properties();
       portProperties.load(fis);
       final String value = portProperties.getProperty(HTTP_JSON_RPC_KEY);
@@ -360,8 +357,8 @@ public class IntegrationTestBase {
     }
   }
 
-  private static void awaitPortsFile(final Path dataDir) {
-    final File file = new File(dataDir.toFile(), PORTS_FILENAME);
+  private static void waitForNonEmptyFileToExist(final Path path) {
+    final File file = path.toFile();
     Awaitility.waitAtMost(30, TimeUnit.SECONDS)
         .until(
             () -> {


### PR DESCRIPTION
Change integration tests to use EthSigner port file to avoid port conflict errors in builds.

There was race condition when using ServerSocket to allocate a free port as the socket was closed after the runner was started. Changing the order would of created another race possible race condition, so instead using the eth ports file.