### PR TITLE
test memory size increase on circleci intg test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ executors:
       - image: circleci/openjdk:11.0.4-jdk-stretch
     resource_class: large
     working_directory: ~/project
+    environment:
+      JAVA_TOOL_OPTIONS: -Xmx4096
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096 -XX:+PrintFlagsFinal
 
   executor_machine:
     machine:
@@ -75,7 +78,7 @@ jobs:
           name: Integration Test
           no_output_timeout: 20m
           command: |
-            ./gradlew --no-daemon --parallel integrationTest --info
+            ./gradlew --no-daemon --parallel integrationTest --info -XX:+PrintFlagsFinal
       - capture_test_results
       - save_cache:
           name: Caching gradle dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
           name: Integration Test
           no_output_timeout: 20m
           command: |
-            ./gradlew --no-daemon --parallel integrationTest --info -XX:+PrintFlagsFinal
+            ./gradlew --no-daemon --parallel integrationTest --info
       - capture_test_results
       - save_cache:
           name: Caching gradle dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
     working_directory: ~/project
     environment:
       JAVA_TOOL_OPTIONS: -Xmx4096m
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096m -XX:+PrintFlagsFinal
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096m
 
   executor_machine:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ executors:
     resource_class: large
     working_directory: ~/project
     environment:
-      JAVA_TOOL_OPTIONS: -Xmx4096
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096 -XX:+PrintFlagsFinal
+      JAVA_TOOL_OPTIONS: -Xmx4096m
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4 -Xmx4096m -XX:+PrintFlagsFinal
 
   executor_machine:
     machine:


### PR DESCRIPTION
testing setting memory limit on integration test executor and limiting the number of executors to see if it improve the build success