### PR TITLE
Remove requirement for 0x in toml filenames

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/AzureBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/AzureBasedTomlLoadingAcceptanceTest.java
@@ -22,7 +22,7 @@ public class AzureBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestB
 
   static final String clientId = System.getenv("ETHSIGNER_AZURE_CLIENT_ID");
   static final String clientSecret = System.getenv("ETHSIGNER_AZURE_CLIENT_SECRET");
-  static final String AZURE_ETHEREUM_ADDRESS = "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73";
+  static final String AZURE_ETHEREUM_ADDRESS = "fe3b557e8fb62b89f4916b721be55ceb828dbd73";
 
   @BeforeAll
   static void preChecks() {
@@ -33,11 +33,12 @@ public class AzureBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestB
 
   @Test
   void azureSignersAreCreatedAndExpectedAddressIsReported() {
-    createAzureTomlFileAt(AZURE_ETHEREUM_ADDRESS + ".toml", clientId, clientSecret);
+    createAzureTomlFileAt(
+        "arbitrary_prefix" + AZURE_ETHEREUM_ADDRESS + ".toml", clientId, clientSecret);
 
     setup();
 
-    assertThat(ethSigner.accounts().list()).containsOnly(AZURE_ETHEREUM_ADDRESS);
+    assertThat(ethSigner.accounts().list()).containsOnly("0x" + AZURE_ETHEREUM_ADDRESS);
   }
 
   @Test

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.Test;
 
 class FileBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestBase {
 
-  static final String FILE_ETHEREUM_ADDRESS = "0xa01f618424b0113a9cebdc6cb66ca5b48e9120c5";
+  static final String FILE_ETHEREUM_ADDRESS = "a01f618424b0113a9cebdc6cb66ca5b48e9120c5";
 
   @Test
   void validFileBasedTomlFileProducesSignerWhicReportsMatchingAddress() throws URISyntaxException {
     createFileBasedTomlFileAt(
-        "a01f618424b0113a9cebdc6cb66ca5b48e9120c5.toml",
+        "arbitrary_prefix" + FILE_ETHEREUM_ADDRESS + ".toml",
         new File(
                 Resources.getResource(
                         "UTC--2019-12-05T05-17-11.151993000Z--a01f618424b0113a9cebdc6cb66ca5b48e9120c5.key")
@@ -41,7 +41,7 @@ class FileBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestBase {
 
     setup();
 
-    assertThat(ethSigner.accounts().list()).containsOnly(FILE_ETHEREUM_ADDRESS);
+    assertThat(ethSigner.accounts().list()).containsOnly("0x" + FILE_ETHEREUM_ADDRESS);
   }
 
   @Test

--- a/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProvider.java
+++ b/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProvider.java
@@ -75,7 +75,7 @@ public class MultiKeyTransactionSignerProvider
       return null;
     }
 
-    if (filenameMatchesSigningAddress(signer.getAddress(), metadataFile)) {
+    if (filenameMatchesSigningAddress(signer, metadataFile)) {
       LOG.info("Loaded signer for address {}", signer.getAddress());
       return signer;
     }
@@ -93,7 +93,7 @@ public class MultiKeyTransactionSignerProvider
       return null;
     }
 
-    if (filenameMatchesSigningAddress(signer.getAddress(), metadataFile)) {
+    if (filenameMatchesSigningAddress(signer, metadataFile)) {
       LOG.info("Loaded signer for address {}", signer.getAddress());
       return signer;
     }
@@ -107,8 +107,7 @@ public class MultiKeyTransactionSignerProvider
       final TransactionSigner signer =
           FileBasedSignerFactory.createSigner(
               metadataFile.getKeyPath(), metadataFile.getPasswordPath());
-      final String signerAddress = signer.getAddress().substring(2); // strip leading 0x
-      if (filenameMatchesSigningAddress(signerAddress, metadataFile)) {
+      if (filenameMatchesSigningAddress(signer, metadataFile)) {
         LOG.info("Loaded signer for address {}", signer.getAddress());
         return signer;
       }
@@ -122,8 +121,9 @@ public class MultiKeyTransactionSignerProvider
   }
 
   private boolean filenameMatchesSigningAddress(
-      final String signerAddress, final SigningMetadataFile metadataFile) {
+      final TransactionSigner signer, final SigningMetadataFile metadataFile) {
 
+    final String signerAddress = signer.getAddress().substring(2); // strip leading 0x
     if (!metadataFile.getBaseFilename().endsWith(signerAddress)) {
       LOG.error(
           String.format(

--- a/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProvider.java
+++ b/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProvider.java
@@ -123,8 +123,9 @@ public class MultiKeyTransactionSignerProvider
   private boolean filenameMatchesSigningAddress(
       final TransactionSigner signer, final SigningMetadataFile metadataFile) {
 
-    final String signerAddress = signer.getAddress().substring(2); // strip leading 0x
-    if (!metadataFile.getBaseFilename().endsWith(signerAddress)) {
+    // strip leading 0x from the address.
+    final String signerAddress = signer.getAddress().substring(2).toLowerCase();
+    if (!metadataFile.getBaseFilename().toLowerCase().endsWith(signerAddress)) {
       LOG.error(
           String.format(
               "Signer's Ethereum Address (%s) does not align with metadata filename (%s)",

--- a/ethsigner/signer/multikey/src/test/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProviderTest.java
+++ b/ethsigner/signer/multikey/src/test/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProviderTest.java
@@ -20,7 +20,6 @@ import static tech.pegasys.ethsigner.signer.multikey.MetadataFileFixture.CONFIG_
 import static tech.pegasys.ethsigner.signer.multikey.MetadataFileFixture.LOWERCASE_ADDRESS;
 import static tech.pegasys.ethsigner.signer.multikey.MetadataFileFixture.copyMetadataFileToDirectory;
 
-import java.net.URISyntaxException;
 import tech.pegasys.ethsigner.core.signing.TransactionSigner;
 import tech.pegasys.ethsigner.signer.azure.AzureKeyVaultAuthenticator;
 import tech.pegasys.ethsigner.signer.azure.AzureKeyVaultTransactionSignerFactory;
@@ -28,6 +27,7 @@ import tech.pegasys.ethsigner.signer.hashicorp.HashicorpSignerFactory;
 import tech.pegasys.ethsigner.signer.multikey.metadata.FileBasedSigningMetadataFile;
 import tech.pegasys.ethsigner.signer.multikey.metadata.SigningMetadataFile;
 
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -41,8 +41,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class MultiKeyTransactionSignerProviderTest {
 
-  @TempDir
-  Path configsDirectory;
+  @TempDir Path configsDirectory;
 
   private SigningMetadataTomlConfigLoader loader = mock(SigningMetadataTomlConfigLoader.class);
   final AzureKeyVaultTransactionSignerFactory azureFactory =
@@ -97,12 +96,15 @@ class MultiKeyTransactionSignerProviderTest {
   @Test
   void signerIsLoadedSuccessfullyWhenAddressHasCaseMismatchToFilename() throws URISyntaxException {
     final FileBasedSigningMetadataFile capitalisedMetadata =
-        new FileBasedSigningMetadataFile(LOWERCASE_ADDRESS.toUpperCase() + ".toml",
+        new FileBasedSigningMetadataFile(
+            LOWERCASE_ADDRESS.toUpperCase() + ".toml",
             Path.of(Resources.getResource("metadata-toml-configs").toURI()).resolve(KEY_FILENAME),
-            Path.of(Resources.getResource("metadata-toml-configs").toURI()).resolve(PASSWORD_FILENAME));
+            Path.of(Resources.getResource("metadata-toml-configs").toURI())
+                .resolve(PASSWORD_FILENAME));
 
     final TransactionSigner signer = signerFactory.createSigner(capitalisedMetadata);
     assertThat(signer).isNotNull();
-    assertThat(capitalisedMetadata.getBaseFilename()).isNotEqualTo(signer.getAddress().substring(2));
+    assertThat(capitalisedMetadata.getBaseFilename())
+        .isNotEqualTo(signer.getAddress().substring(2));
   }
 }

--- a/ethsigner/signer/multikey/src/test/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProviderTest.java
+++ b/ethsigner/signer/multikey/src/test/java/tech/pegasys/ethsigner/signer/multikey/MultiKeyTransactionSignerProviderTest.java
@@ -83,7 +83,9 @@ class MultiKeyTransactionSignerProviderTest {
   void getSignerForAvailableMetadataReturnsSigner() {
     when(loader.loadMetadataForAddress(LOWERCASE_ADDRESS)).thenReturn(Optional.of(metadataFile));
 
-    assertThat(signerFactory.getSigner(LOWERCASE_ADDRESS)).isNotEmpty();
+    final Optional<TransactionSigner> signer = signerFactory.getSigner(LOWERCASE_ADDRESS);
+    assertThat(signer).isNotEmpty();
+    assertThat(signer.get().getAddress()).isEqualTo("0x" + LOWERCASE_ADDRESS);
   }
 
   @Test
@@ -106,5 +108,6 @@ class MultiKeyTransactionSignerProviderTest {
     assertThat(signer).isNotNull();
     assertThat(capitalisedMetadata.getBaseFilename())
         .isNotEqualTo(signer.getAddress().substring(2));
+    assertThat(signer.getAddress()).isEqualTo("0x" + LOWERCASE_ADDRESS);
   }
 }


### PR DESCRIPTION
A signer reports its address with an 0x prefix, which is then compared against toml filename - however the filename should _not_ be required to contain "0x".

This fix removes the 0x from the signer's address prior to comparing it with the filename.