### PR TITLE
Pass through hostname to Vertx http client options

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -51,13 +51,15 @@ public class EthSignerBaseCommand implements Config {
           "Logging verbosity levels: OFF, FATAL, WARN, INFO, DEBUG, TRACE, ALL (default: INFO)")
   private final Level logLevel = Level.INFO;
 
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
       names = "--downstream-http-host",
       description =
           "The endpoint to which received requests are forwarded (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final InetAddress downstreamHttpHost = InetAddress.getLoopbackAddress();
+  private String downstreamHttpHost = InetAddress.getLoopbackAddress().getHostAddress();
 
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires primitives to not be final.
   @Option(
       names = "--downstream-http-port",
       description = "The endpoint to which received requests are forwarded",
@@ -78,7 +80,7 @@ public class EthSignerBaseCommand implements Config {
       names = {"--http-listen-host"},
       description = "Host for JSON-RPC HTTP to listen on (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final InetAddress httpListenHost = InetAddress.getLoopbackAddress();
+  private String httpListenHost = InetAddress.getLoopbackAddress().getHostAddress();
 
   @Option(
       names = {"--http-listen-port"},
@@ -106,7 +108,7 @@ public class EthSignerBaseCommand implements Config {
   }
 
   @Override
-  public InetAddress getDownstreamHttpHost() {
+  public String getDownstreamHttpHost() {
     return downstreamHttpHost;
   }
 
@@ -116,7 +118,7 @@ public class EthSignerBaseCommand implements Config {
   }
 
   @Override
-  public InetAddress getHttpListenHost() {
+  public String getHttpListenHost() {
     return httpListenHost;
   }
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -59,7 +59,7 @@ public class EthSignerBaseCommand implements Config {
       arity = "1")
   private String downstreamHttpHost = InetAddress.getLoopbackAddress().getHostAddress();
 
-  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires primitives to not be final.
+  @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
       names = "--downstream-http-port",
       description = "The endpoint to which received requests are forwarded",

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -79,10 +79,10 @@ public class CommandlineParserTest {
     assertThat(result).isTrue();
 
     assertThat(config.getLogLevel()).isEqualTo(Level.INFO);
-    assertThat(config.getDownstreamHttpHost()).isEqualTo(InetAddress.getByName("8.8.8.8"));
+    assertThat(config.getDownstreamHttpHost()).isEqualTo("8.8.8.8");
     assertThat(config.getDownstreamHttpPort()).isEqualTo(5000);
     assertThat(config.getDownstreamHttpRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-    assertThat(config.getHttpListenHost()).isEqualTo(InetAddress.getByName("localhost"));
+    assertThat(config.getHttpListenHost()).isEqualTo("localhost");
     assertThat(config.getHttpListenPort()).isEqualTo(5001);
   }
 
@@ -139,7 +139,9 @@ public class CommandlineParserTest {
   @Test
   public void missingDownStreamHostDefaultsToLoopback() {
     missingOptionalParameterIsValidAndMeetsDefault(
-        "downstream-http-host", config::getDownstreamHttpHost, InetAddress.getLoopbackAddress());
+        "downstream-http-host",
+        config::getDownstreamHttpHost,
+        InetAddress.getLoopbackAddress().getHostAddress());
   }
 
   @Test
@@ -159,7 +161,9 @@ public class CommandlineParserTest {
   @Test
   public void missingListenHostDefaultsToLoopback() {
     missingOptionalParameterIsValidAndMeetsDefault(
-        "http-listen-host", config::getHttpListenHost, InetAddress.getLoopbackAddress());
+        "http-listen-host",
+        config::getHttpListenHost,
+        InetAddress.getLoopbackAddress().getHostAddress());
   }
 
   @Test
@@ -202,22 +206,6 @@ public class CommandlineParserTest {
     assertThat(result).isTrue();
     assertThat(actualValueGetter.get()).isEqualTo(expectedValue);
     assertThat(commandOutput.toString()).isEmpty();
-  }
-
-  @Test
-  public void domainNamesDecodeIntoAnInetAddress() {
-    final String input =
-        "--downstream-http-host=google.com "
-            + "--downstream-http-port=5000 "
-            + "--downstream-http-request-timeout=10000 "
-            + "--http-listen-port=5001 "
-            + "--http-listen-host=localhost "
-            + "--chain-id=6 "
-            + "--logging=INFO";
-    final String[] inputArgs = input.split(" ");
-
-    parser.parseCommandLine(inputArgs);
-    assertThat(config.getDownstreamHttpHost().getHostName()).isEqualTo("google.com");
   }
 
   @Test

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Config.java
@@ -14,7 +14,6 @@ package tech.pegasys.ethsigner.core;
 
 import tech.pegasys.ethsigner.core.signing.ChainIdProvider;
 
-import java.net.InetAddress;
 import java.nio.file.Path;
 import java.time.Duration;
 
@@ -24,13 +23,13 @@ public interface Config {
 
   Level getLogLevel();
 
-  InetAddress getDownstreamHttpHost();
+  String getDownstreamHttpHost();
 
   Integer getDownstreamHttpPort();
 
   Duration getDownstreamHttpRequestTimeout();
 
-  InetAddress getHttpListenHost();
+  String getHttpListenHost();
 
   Integer getHttpListenPort();
 

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -62,11 +62,11 @@ public final class EthSigner {
     final WebClientOptions clientOptions =
         new WebClientOptions()
             .setDefaultPort(config.getDownstreamHttpPort())
-            .setDefaultHost(config.getDownstreamHttpHost().getHostAddress());
+            .setDefaultHost(config.getDownstreamHttpHost());
     final HttpServerOptions serverOptions =
         new HttpServerOptions()
             .setPort(config.getHttpListenPort())
-            .setHost(config.getHttpListenHost().getHostAddress())
+            .setHost(config.getHttpListenHost())
             .setReuseAddress(true)
             .setReusePort(true);
     final Path dataPath = config.getDataPath();
@@ -96,10 +96,7 @@ public final class EthSigner {
 
   private HttpService createWeb3jHttpService() {
     final String downstreamUrl =
-        "http://"
-            + config.getDownstreamHttpHost().getHostName()
-            + ":"
-            + config.getDownstreamHttpPort();
+        "http://" + config.getDownstreamHttpHost() + ":" + config.getDownstreamHttpPort();
     LOG.info("Downstream URL = {}", downstreamUrl);
 
     final OkHttpClient.Builder builder = new OkHttpClient.Builder();


### PR DESCRIPTION
Pass through hostname to Vertx http client options instead of the ip address. This way the hostname can be resolved on demand if a hostname is used. And if a ip address is used, this ip address will always be used.