### PR TITLE
Update cli param labels

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/DefaultCommandValues.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/DefaultCommandValues.java
@@ -14,4 +14,8 @@ package tech.pegasys.ethsigner;
 
 public interface DefaultCommandValues {
   String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
+  String MANDATORY_DIRECTORY_FORMAT_HELP = "<DIRECTORY>";
+  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
+  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
+  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
 }

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/DefaultCommandValues.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/DefaultCommandValues.java
@@ -14,7 +14,7 @@ package tech.pegasys.ethsigner;
 
 public interface DefaultCommandValues {
   String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_DIRECTORY_FORMAT_HELP = "<DIRECTORY>";
+  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
   String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
   String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
   String MANDATORY_LONG_FORMAT_HELP = "<LONG>";

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -12,9 +12,9 @@
  */
 package tech.pegasys.ethsigner;
 
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
 
 import tech.pegasys.ethsigner.config.PicoCliTlsServerOptions;
@@ -68,7 +68,7 @@ public class EthSignerBaseCommand implements Config {
   @Option(
       names = {"--data-path"},
       description = "The path to a directory to store temporary files",
-      paramLabel = MANDATORY_DIRECTORY_FORMAT_HELP,
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
       arity = "1")
   private Path dataPath;
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -32,6 +32,12 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Option;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+
+
 @SuppressWarnings("FieldCanBeLocal") // because Picocli injected fields report false positives
 @Command(
     description =
@@ -62,6 +68,7 @@ public class EthSignerBaseCommand implements Config {
   @Option(
       names = {"--data-path"},
       description = "The path to a directory to store temporary files",
+      paramLabel = MANDATORY_DIRECTORY_FORMAT_HELP,
       arity = "1")
   private Path dataPath;
 
@@ -76,12 +83,14 @@ public class EthSignerBaseCommand implements Config {
   @Option(
       names = {"--http-listen-host"},
       description = "Host for JSON-RPC HTTP to listen on (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
       arity = "1")
   private String httpListenHost = InetAddress.getLoopbackAddress().getHostAddress();
 
   @Option(
       names = {"--http-listen-port"},
       description = "Port for JSON-RPC HTTP to listen on (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_PORT_FORMAT_HELP,
       arity = "1")
   private final Integer httpListenPort = 8545;
 
@@ -93,6 +102,7 @@ public class EthSignerBaseCommand implements Config {
       names = "--downstream-http-host",
       description =
           "The endpoint to which received requests are forwarded (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
       arity = "1")
   private String downstreamHttpHost = InetAddress.getLoopbackAddress().getHostAddress();
 
@@ -100,6 +110,7 @@ public class EthSignerBaseCommand implements Config {
   @Option(
       names = "--downstream-http-port",
       description = "The endpoint to which received requests are forwarded",
+      paramLabel = MANDATORY_PORT_FORMAT_HELP,
       required = true,
       arity = "1")
   private Integer downstreamHttpPort;
@@ -109,6 +120,7 @@ public class EthSignerBaseCommand implements Config {
       names = {"--downstream-http-request-timeout"},
       description =
           "Timeout in milliseconds to wait for downstream request (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
       arity = "1")
   private long downstreamHttpRequestTimeout = Duration.ofSeconds(5).toMillis();
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -61,6 +61,7 @@ public class EthSignerBaseCommand implements Config {
       names = {"--chain-id"},
       description = "The Chain Id that will be the intended recipient for signed transactions",
       required = true,
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
       arity = "1")
   private long chainId;
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -12,6 +12,11 @@
  */
 package tech.pegasys.ethsigner;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+
 import tech.pegasys.ethsigner.config.PicoCliTlsServerOptions;
 import tech.pegasys.ethsigner.config.tls.client.PicoCliClientTlsOptions;
 import tech.pegasys.ethsigner.core.config.Config;
@@ -31,12 +36,6 @@ import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Option;
-
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
-
 
 @SuppressWarnings("FieldCanBeLocal") // because Picocli injected fields report false positives
 @Command(

--- a/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
+++ b/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.ethsigner.signer.azure;
 
+import tech.pegasys.ethsigner.DefaultCommandValues;
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
@@ -26,6 +27,8 @@ import com.google.common.base.Charsets;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
 @Command(
     name = AzureSubCommand.COMMAND_NAME,
     description = "Sign transactions using the Azure signing service.",
@@ -36,24 +39,28 @@ public class AzureSubCommand extends SignerSubCommand {
       names = {"--keyvault-name", "--key-vault-name"},
       description = "Name of the vault to access - used as the sub-domain to vault.azure.net",
       required = true,
+      paramLabel = "<KEY_VAULT_NAME>",
       arity = "1")
   private String keyVaultName;
 
   @Option(
       names = {"--key-name"},
       description = "The name of the key which is to be used",
+      paramLabel = "<KEY_NAME>",
       required = true)
   private String keyName;
 
   @Option(
       names = {"--key-version"},
       description = "The version of the requested key to use",
+      paramLabel = "<KEY_VERSION>",
       required = true)
   private String keyVersion;
 
   @Option(
       names = {"--client-id"},
       description = "The ID used to authenticate with Azure key vault",
+      paramLabel = "<CLIENT_ID>",
       required = true)
   private String clientId;
 
@@ -61,6 +68,7 @@ public class AzureSubCommand extends SignerSubCommand {
       names = {"--client-secret-path"},
       description =
           "Path to a file containing the secret used to access the vault (along with client-id)",
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
       required = true)
   private Path clientSecretPath;
 

--- a/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
+++ b/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
@@ -12,7 +12,8 @@
  */
 package tech.pegasys.ethsigner.signer.azure;
 
-import tech.pegasys.ethsigner.DefaultCommandValues;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
@@ -26,8 +27,6 @@ import java.nio.file.Path;
 import com.google.common.base.Charsets;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
 
 @Command(
     name = AzureSubCommand.COMMAND_NAME,

--- a/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
+++ b/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.ethsigner.signer.azure;
 
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
 
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
@@ -67,7 +67,7 @@ public class AzureSubCommand extends SignerSubCommand {
       names = {"--client-secret-path"},
       description =
           "Path to a file containing the secret used to access the vault (along with client-id)",
-      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
       required = true)
   private Path clientSecretPath;
 

--- a/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/FileBasedSubCommand.java
+++ b/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/FileBasedSubCommand.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.ethsigner.signer.filebased;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
@@ -45,6 +47,7 @@ public class FileBasedSubCommand extends SignerSubCommand {
       names = {"-p", "--password-file"},
       description = "The path to a file containing the password used to decrypt the keyfile.",
       required = true,
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
       arity = "1")
   private Path passwordFilePath;
 
@@ -53,6 +56,7 @@ public class FileBasedSubCommand extends SignerSubCommand {
       names = {"-k", "--key-file"},
       description = "The path to a file containing the key used to sign transactions.",
       required = true,
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
       arity = "1")
   private Path keyFilePath;
 

--- a/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSubCommand.java
+++ b/ethsigner/signer/hashicorp/src/main/java/tech/pegasys/ethsigner/signer/hashicorp/HashicorpSubCommand.java
@@ -12,6 +12,11 @@
  */
 package tech.pegasys.ethsigner.signer.hashicorp;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_HELP;
+
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
@@ -44,12 +49,14 @@ public class HashicorpSubCommand extends SignerSubCommand {
   @Option(
       names = {"--host"},
       description = "Host of the Hashicorp vault server (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
       arity = "1")
   private String serverHost = DEFAULT_HASHICORP_VAULT_HOST;
 
   @Option(
       names = {"--port"},
       description = "Port of the Hashicorp vault server (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_PORT_FORMAT_HELP,
       arity = "1")
   private final Integer serverPort = DEFAULT_PORT;
 
@@ -57,6 +64,7 @@ public class HashicorpSubCommand extends SignerSubCommand {
       names = {"--timeout"},
       description =
           "Timeout in milliseconds for requests to the Hashicorp vault server (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
       arity = "1")
   private final Long timeout = DEFAULT_TIMEOUT;
 
@@ -64,6 +72,7 @@ public class HashicorpSubCommand extends SignerSubCommand {
       names = {"--auth-file"},
       description = "Path to a File containing authentication data for Hashicorp vault",
       required = true,
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
       arity = "1")
   private final Path authFilePath = null;
 
@@ -73,6 +82,7 @@ public class HashicorpSubCommand extends SignerSubCommand {
       description =
           "Path to a secret in the Hashicorp vault containing the private key used for signing transactions. The "
               + "key needs to be a base 64 encoded private key for ECDSA for curve secp256k1 (default: ${DEFAULT-VALUE})",
+      paramLabel = "<SIGNING_KEY_PATH>",
       arity = "1")
   private String signingKeyPath = DEFAULT_KEY_PATH;
 
@@ -86,6 +96,7 @@ public class HashicorpSubCommand extends SignerSubCommand {
       names = "--tls-known-server-file",
       description =
           "Path to the file containing Hashicorp Vault's host, port and self-signed certificate fingerprint",
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
       arity = "1")
   private final Path tlsKnownServerFile = null;
 

--- a/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeySubCommand.java
+++ b/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeySubCommand.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.ethsigner.signer.multikey;
 
-import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
 
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
@@ -54,7 +54,7 @@ public class MultiKeySubCommand extends SignerSubCommand {
       names = {"-d", "--directory"},
       description = "The path to a directory containing signing metadata TOML files",
       required = true,
-      paramLabel = MANDATORY_DIRECTORY_FORMAT_HELP,
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
       arity = "1")
   private Path directoryPath;
 

--- a/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeySubCommand.java
+++ b/ethsigner/signer/multikey/src/main/java/tech/pegasys/ethsigner/signer/multikey/MultiKeySubCommand.java
@@ -12,6 +12,8 @@
  */
 package tech.pegasys.ethsigner.signer.multikey;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_DIRECTORY_FORMAT_HELP;
+
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.TransactionSignerProvider;
@@ -52,6 +54,7 @@ public class MultiKeySubCommand extends SignerSubCommand {
       names = {"-d", "--directory"},
       description = "The path to a directory containing signing metadata TOML files",
       required = true,
+      paramLabel = MANDATORY_DIRECTORY_FORMAT_HELP,
       arity = "1")
   private Path directoryPath;
 


### PR DESCRIPTION
Update cli option labels to use standardised param labels so that picocli doesn't print variable names. 