### PR TITLE
Fix private transaction AT now that Besu requires the nonce to be valid when submitted

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/signing/PrivateTransactionAcceptanceTest.java
@@ -40,7 +40,7 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
     final PrivateTransaction contract =
         PrivateTransaction.createContractTransaction(
             richBenefactor().address(),
-            richBenefactor().nextNonceAndIncrement(),
+            BigInteger.ZERO,
             GAS_PRICE,
             GAS_LIMIT,
             BigInteger.ZERO,
@@ -62,7 +62,7 @@ public class PrivateTransactionAcceptanceTest extends AcceptanceTestBase {
     final PrivateTransaction transaction =
         PrivateTransaction.createEtherTransaction(
             richBenefactor().address(),
-            Optional.of(richBenefactor().nextNonceAndIncrement()),
+            Optional.of(BigInteger.ZERO),
             GAS_PRICE,
             GAS_LIMIT,
             RECIPIENT,


### PR DESCRIPTION
Fix private transaction AT now that Besu requires the nonce to be valid when submitted

We were incrementing the nonce being used in the test even when we expected the transaction to fail. This didn't matter previously for private transactions as weren't doing full validation. Now we are this fails.