### PR TITLE
Force R and S values to be positive in signature

### DIFF
--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
@@ -1,5 +1,5 @@
-package tech.pegasys.ethsigner.signer.filebased;/*
- * Copyright ConsenSys AG.
+/*
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,25 +9,20 @@ package tech.pegasys.ethsigner.signer.filebased;/*
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
+package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-import java.math.BigInteger;
-import org.junit.jupiter.api.Test;
-import org.web3j.crypto.Credentials;
-import org.web3j.crypto.RawTransaction;
-import org.web3j.crypto.TransactionEncoder;
 import tech.pegasys.ethsigner.core.jsonrpc.EthSendTransactionJsonParameters;
-import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequestId;
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.EthTransaction;
 import tech.pegasys.ethsigner.core.signing.Signature;
-import tech.pegasys.ethsigner.core.signing.TransactionSerializer;
+import tech.pegasys.ethsigner.signer.filebased.CredentialTransactionSigner;
 
-class CredentialTransactionSignerTest {
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Credentials;
+
+class IllegalSignatureCreationTest {
 
   @Test
   void ensureZenDesk32060IsResolved() {
@@ -42,17 +37,16 @@ class CredentialTransactionSignerTest {
     txnParams.data("0x0");
     txnParams.receiver("0x627306090abaB3A6e1400e9345bC60c78a8BEf57");
 
-    final EthTransaction txn = new EthTransaction(txnParams, null, new JsonRpcRequestId(1));
-
+    final EthTransaction txn = new EthTransaction(txnParams, null, null);
     final byte[] serialisedBytes = txn.rlpEncode(chainId);
 
-    CredentialTransactionSigner signer = new CredentialTransactionSigner(
-        Credentials.create("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
+    CredentialTransactionSigner signer =
+        new CredentialTransactionSigner(
+            Credentials.create("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
 
     final Signature signature = signer.sign(serialisedBytes);
 
     assertThat(signature.getR().signum()).isOne();
     assertThat(signature.getS().signum()).isOne();
   }
-
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
@@ -25,7 +25,11 @@ import org.web3j.crypto.Credentials;
 class IllegalSignatureCreationTest {
 
   @Test
-  void ensureZenDesk32060IsResolved() {
+  void ensureSignaturesCreatedHavePositiveValues() {
+    // This problem was identified in Zendesk ticket 32060, which identified a specific
+    // transaction being signed with a given key, resulted in the transaction being rejected by
+    // Besu due to "INVALID SIGNATURE" - ultimately, it was came down to byte[] --> BigInt resulting
+    // in negative value.
     final long chainId = 44844;
 
     final EthSendTransactionJsonParameters txnParams =
@@ -40,7 +44,7 @@ class IllegalSignatureCreationTest {
     final EthTransaction txn = new EthTransaction(txnParams, null, null);
     final byte[] serialisedBytes = txn.rlpEncode(chainId);
 
-    CredentialTransactionSigner signer =
+    final CredentialTransactionSigner signer =
         new CredentialTransactionSigner(
             Credentials.create("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IllegalSignatureCreationTest.java
@@ -26,7 +26,7 @@ class IllegalSignatureCreationTest {
 
   @Test
   void ensureSignaturesCreatedHavePositiveValues() {
-    // This problem was identified in Zendesk ticket 32060, which identified a specific
+    // This problem was identified in Github Issue #247, which identified a specific
     // transaction being signed with a given key, resulted in the transaction being rejected by
     // Besu due to "INVALID SIGNATURE" - ultimately, it was came down to byte[] --> BigInt resulting
     // in negative value.

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EthTransaction.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/EthTransaction.java
@@ -36,7 +36,7 @@ public class EthTransaction implements Transaction {
   private final JsonRpcRequestId id;
   private BigInteger nonce;
 
-  EthTransaction(
+  public EthTransaction(
       final EthSendTransactionJsonParameters transactionJsonParameters,
       final NonceProvider nonceProvider,
       final JsonRpcRequestId id) {

--- a/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/CredentialTransactionSigner.java
+++ b/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/CredentialTransactionSigner.java
@@ -34,8 +34,8 @@ public class CredentialTransactionSigner implements TransactionSigner {
     final SignatureData signature = Sign.signMessage(data, credentials.getEcKeyPair());
     return new Signature(
         new BigInteger(signature.getV()),
-        new BigInteger(signature.getR()),
-        new BigInteger(signature.getS()));
+        new BigInteger(1, signature.getR()),
+        new BigInteger(1, signature.getS()));
   }
 
   @Override

--- a/ethsigner/signer/file-based/src/test/java/tech/pegasys/ethsigner/signer/filebased/CredentialTransactionSignerTest.java
+++ b/ethsigner/signer/file-based/src/test/java/tech/pegasys/ethsigner/signer/filebased/CredentialTransactionSignerTest.java
@@ -1,0 +1,58 @@
+package tech.pegasys.ethsigner.signer.filebased;/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.RawTransaction;
+import org.web3j.crypto.TransactionEncoder;
+import tech.pegasys.ethsigner.core.jsonrpc.EthSendTransactionJsonParameters;
+import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequestId;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.EthTransaction;
+import tech.pegasys.ethsigner.core.signing.Signature;
+import tech.pegasys.ethsigner.core.signing.TransactionSerializer;
+
+class CredentialTransactionSignerTest {
+
+  @Test
+  void ensureZenDesk32060IsResolved() {
+    final long chainId = 44844;
+
+    final EthSendTransactionJsonParameters txnParams =
+        new EthSendTransactionJsonParameters("0xf17f52151ebef6c7334fad080c5704d77216b732");
+    txnParams.gasPrice("0x0");
+    txnParams.gas("0x7600");
+    txnParams.nonce("0x46");
+    txnParams.value("0x1");
+    txnParams.data("0x0");
+    txnParams.receiver("0x627306090abaB3A6e1400e9345bC60c78a8BEf57");
+
+    final EthTransaction txn = new EthTransaction(txnParams, null, new JsonRpcRequestId(1));
+
+    final byte[] serialisedBytes = txn.rlpEncode(chainId);
+
+    CredentialTransactionSigner signer = new CredentialTransactionSigner(
+        Credentials.create("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f"));
+
+    final Signature signature = signer.sign(serialisedBytes);
+
+    assertThat(signature.getR().signum()).isOne();
+    assertThat(signature.getS().signum()).isOne();
+  }
+
+}


### PR DESCRIPTION
When Ethsigner wraps the signature byte arrays from Web3j, and stores them in a Signature object, the BigIntegers _must_ be positive to ensure the signature is valid (and can be used to recover the sending address).

fixes #247