### PR TITLE
#234 - Update docker-java library version

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/DockerClientFactory.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/DockerClientFactory.java
@@ -29,10 +29,10 @@ public class DockerClientFactory {
   private DockerClient createDockerClient(final DefaultDockerClientConfig config) {
     final DockerCmdExecFactory dockerCmdExecFactory =
         new JerseyDockerCmdExecFactory()
-            .withReadTimeout(7500)
-            .withConnectTimeout(7500)
             .withMaxTotalConnections(100)
-            .withMaxPerRouteConnections(10);
+            .withMaxPerRouteConnections(10)
+            .withReadTimeout(7500)
+            .withConnectTimeout(7500);
 
     return DockerClientBuilder.getInstance(config)
         .withDockerCmdExecFactory(dockerCmdExecFactory)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.github.docker-java:docker-java:3.1.1'
+    dependency 'com.github.docker-java:docker-java:3.2.0'
 
     dependency 'com.google.errorprone:error_prone_annotation:2.3.4'
     dependency 'com.google.errorprone:error_prone_check_api:2.3.4'


### PR DESCRIPTION
 -- The updated version allows acceptance tests to run against > JDK 13

Fixes #234 

Signed-off-by: Usman Saleem <usman@usmans.info>