### PR TITLE
Repair empty license reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,7 +406,7 @@ startScripts {
 }
 
 dependencies {
-  implementation project(':ethsigner:app')
+  compile project(':ethsigner:app')
   errorprone 'com.google.errorprone:error_prone_core'
 }
 


### PR DESCRIPTION
The licensing gradle plugin being used requires that the root
project have a "compile" dependency on the application module -
otherwise no licenses are identified when walking the dependency
tree.