### PR TITLE
[#253] Read password from the first line of the file 

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
@@ -15,7 +15,9 @@ package tech.pegasys.ethsigner.tests.multikeysigner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import com.google.common.io.Resources;
@@ -42,6 +44,25 @@ class FileBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestBase {
                         "UTC--2019-12-05T05-17-11.151993000Z--a01f618424b0113a9cebdc6cb66ca5b48e9120c5.password")
                     .toURI())
             .getAbsolutePath());
+
+    setup(tomlDirectory);
+
+    assertThat(ethSigner.accounts().list()).containsOnly(FILE_ETHEREUM_ADDRESS);
+  }
+
+  @Test
+  void validFileBasedTomlFileWithMultineLinePasswordFileProducesSignerWhichReportsMatchingAddress(
+      @TempDir Path tomlDirectory) throws URISyntaxException, IOException {
+    final Path passwordFile =
+        Files.writeString(tomlDirectory.resolve("password.txt"), "password\nsecond line\n");
+    createFileBasedTomlFileAt(
+        tomlDirectory.resolve("arbitrary_prefix" + FILENAME + ".toml").toAbsolutePath(),
+        new File(
+                Resources.getResource(
+                        "UTC--2019-12-05T05-17-11.151993000Z--a01f618424b0113a9cebdc6cb66ca5b48e9120c5.key")
+                    .toURI())
+            .getAbsolutePath(),
+        passwordFile.toString());
 
     setup(tomlDirectory);
 

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/multikeysigner/FileBasedTomlLoadingAcceptanceTest.java
@@ -54,7 +54,8 @@ class FileBasedTomlLoadingAcceptanceTest extends MultiKeyAcceptanceTestBase {
   void validFileBasedTomlFileWithMultineLinePasswordFileProducesSignerWhichReportsMatchingAddress(
       @TempDir Path tomlDirectory) throws URISyntaxException, IOException {
     final Path passwordFile =
-        Files.writeString(tomlDirectory.resolve("password.txt"), "password\nsecond line\n");
+        Files.writeString(
+            tomlDirectory.resolve("password.txt"), String.format("password%nsecond line%n"));
     createFileBasedTomlFileAt(
         tomlDirectory.resolve("arbitrary_prefix" + FILENAME + ".toml").toAbsolutePath(),
         new File(

--- a/ethsigner/commandline/build.gradle
+++ b/ethsigner/commandline/build.gradle
@@ -23,6 +23,7 @@ dependencies {
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
 

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/util/PasswordFileUtil.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/util/PasswordFileUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import tech.pegasys.ethsigner.TransactionSignerInitializationException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.google.common.io.Files;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PasswordFileUtil {
+  private static final Logger LOG = LogManager.getLogger();
+
+  /**
+   * Read password from the first line of specified file
+   *
+   * @param path The file to read the password from
+   * @return Password
+   * @throws IOException For file operations
+   * @throws TransactionSignerInitializationException If password file is empty
+   */
+  public static String readPasswordFromFile(final Path path) throws IOException {
+    final String password = Files.asCharSource(path.toFile(), UTF_8).readFirstLine();
+    if (password == null || password.isEmpty()) {
+      LOG.error("Cannot read password from empty file: " + path);
+      throw new TransactionSignerInitializationException(
+          "Cannot read password from empty file: " + path);
+    }
+    return password;
+  }
+}

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/util/PasswordFileUtilTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/util/PasswordFileUtilTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import tech.pegasys.ethsigner.TransactionSignerInitializationException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PasswordFileUtilTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"line1\nline2", "line1\n", "line1"})
+  void canReadPasswordFromFile(final String content, @TempDir final Path tempDir)
+      throws IOException {
+    final Path passwordFile = Files.write(tempDir.resolve("password.txt"), content.getBytes(UTF_8));
+    assertThat(PasswordFileUtil.readPasswordFromFile(passwordFile)).isEqualTo("line1");
+  }
+
+  @Test
+  void canReadSpaceOnlyPasswordFromFile(@TempDir final Path tempDir) throws IOException {
+    final Path passwordFile = Files.write(tempDir.resolve("password.txt"), "   \n".getBytes(UTF_8));
+    assertThat(PasswordFileUtil.readPasswordFromFile(passwordFile)).isEqualTo("   ");
+  }
+
+  @Test
+  void emptyFileThrowsException(@TempDir final Path tempDir) throws IOException {
+    final Path passwordFile = Files.write(tempDir.resolve("password.txt"), new byte[0]);
+    assertThatExceptionOfType(TransactionSignerInitializationException.class)
+        .isThrownBy(() -> PasswordFileUtil.readPasswordFromFile(passwordFile))
+        .withMessage("Cannot read password from empty file: %s", passwordFile);
+  }
+
+  @Test
+  void fileWithEolOnlyThrowsException(@TempDir final Path tempDir) throws IOException {
+    final Path passwordFile = Files.write(tempDir.resolve("password.txt"), "\n".getBytes(UTF_8));
+    assertThatExceptionOfType(TransactionSignerInitializationException.class)
+        .isThrownBy(() -> PasswordFileUtil.readPasswordFromFile(passwordFile))
+        .withMessage("Cannot read password from empty file: %s", passwordFile);
+  }
+}

--- a/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
+++ b/ethsigner/signer/azure/src/main/java/tech/pegasys/ethsigner/signer/azure/AzureSubCommand.java
@@ -13,6 +13,7 @@
 package tech.pegasys.ethsigner.signer.azure;
 
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
+import static tech.pegasys.ethsigner.util.PasswordFileUtil.readPasswordFromFile;
 
 import tech.pegasys.ethsigner.SignerSubCommand;
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
@@ -20,11 +21,10 @@ import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
 import tech.pegasys.ethsigner.core.signing.TransactionSigner;
 import tech.pegasys.ethsigner.core.signing.TransactionSignerProvider;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.google.common.base.Charsets;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -77,7 +77,9 @@ public class AzureSubCommand extends SignerSubCommand {
   private TransactionSigner createSigner() throws TransactionSignerInitializationException {
     final String clientSecret;
     try {
-      clientSecret = readSecretFromFile(clientSecretPath);
+      clientSecret = readPasswordFromFile(clientSecretPath);
+    } catch (final FileNotFoundException fnfe) {
+      throw new TransactionSignerInitializationException("File not found: " + clientSecretPath);
     } catch (final IOException e) {
       throw new TransactionSignerInitializationException(READ_SECRET_FILE_ERROR, e);
     }
@@ -100,10 +102,5 @@ public class AzureSubCommand extends SignerSubCommand {
   @Override
   public String getCommandName() {
     return COMMAND_NAME;
-  }
-
-  private static String readSecretFromFile(final Path path) throws IOException {
-    final byte[] fileContent = Files.readAllBytes(path);
-    return new String(fileContent, Charsets.UTF_8);
   }
 }

--- a/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/FileBasedSignerFactory.java
+++ b/ethsigner/signer/file-based/src/main/java/tech/pegasys/ethsigner/signer/filebased/FileBasedSignerFactory.java
@@ -12,14 +12,15 @@
  */
 package tech.pegasys.ethsigner.signer.filebased;
 
+import static tech.pegasys.ethsigner.util.PasswordFileUtil.readPasswordFromFile;
+
 import tech.pegasys.ethsigner.TransactionSignerInitializationException;
 import tech.pegasys.ethsigner.core.signing.TransactionSigner;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.google.common.base.Charsets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.web3j.crypto.CipherException;
@@ -40,6 +41,9 @@ public class FileBasedSignerFactory {
     final String password;
     try {
       password = readPasswordFromFile(passwordFilePath);
+    } catch (final FileNotFoundException fnfe) {
+      LOG.error("File not found: " + passwordFilePath);
+      throw new TransactionSignerInitializationException("File not found: " + passwordFilePath);
     } catch (final IOException e) {
       final String message = READ_PWD_FILE_MESSAGE;
       LOG.error(message, e);
@@ -57,10 +61,5 @@ public class FileBasedSignerFactory {
       LOG.error(message, e);
       throw new TransactionSignerInitializationException(message, e);
     }
-  }
-
-  private static String readPasswordFromFile(final Path path) throws IOException {
-    final byte[] fileContent = Files.readAllBytes(path);
-    return new String(fileContent, Charsets.UTF_8);
   }
 }


### PR DESCRIPTION
 - this commit fixes the issue where text editors often adds eol when creating text file which resulted in error when EthSigner attempted to read the whole file as bytes (which included eol character as well).

Signed-off-by: Usman Saleem <usman@usmans.info>