### PR TITLE
Add downstream-http-request-args to support Infura integration

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -110,10 +110,11 @@ public class EthSignerBaseCommand implements Config {
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"--downstream-http-request-args"},
-      description = "Query String to append to the http request (e.g. infura)",
-      paramLabel = MANDATORY_LONG_FORMAT_HELP,
+      description =
+          "Query String to append to the http request (e.g. full infura url with project id)",
+      paramLabel = MANDATORY_HOST_FORMAT_HELP,
       arity = "1")
-  private String downstreamHttpRequestArgs;
+  private String downstreamHttpRequestArgs = "/";
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.ethsigner;
 
+import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_BOOLEAN_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_HOST_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
 import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
@@ -107,15 +108,6 @@ public class EthSignerBaseCommand implements Config {
       arity = "1")
   private String downstreamHttpHost = InetAddress.getLoopbackAddress().getHostAddress();
 
-  @SuppressWarnings("FieldMayBeFinal")
-  @Option(
-      names = {"--downstream-http-request-args"},
-      description =
-          "Query String to append to the http request (e.g. full infura url with project id)",
-      paramLabel = MANDATORY_HOST_FORMAT_HELP,
-      arity = "1")
-  private String downstreamHttpRequestArgs = "/";
-
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
       names = "--downstream-http-port",
@@ -124,6 +116,23 @@ public class EthSignerBaseCommand implements Config {
       required = true,
       arity = "1")
   private Integer downstreamHttpPort;
+
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"--downstream-http-path"},
+      description = "The path to which received requests are forwarded",
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
+      arity = "1")
+  private String downstreamHttpPath = "";
+
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"--downstream-http-replace-path"},
+      description =
+          "Flag indicating if downstream-http-path should replace the uri request (default: ${DEFAULT-VALUE})",
+      paramLabel = MANDATORY_BOOLEAN_FORMAT_HELP,
+      arity = "0")
+  private boolean downstreamHttpReplacePath = false;
 
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
@@ -153,8 +162,13 @@ public class EthSignerBaseCommand implements Config {
   }
 
   @Override
-  public String getDownstreamHttpRequestArgs() {
-    return downstreamHttpRequestArgs;
+  public String getDownstreamHttpPath() {
+    return downstreamHttpPath;
+  }
+
+  @Override
+  public boolean getDownstreamHttpReplacePath() {
+    return downstreamHttpReplacePath;
   }
 
   @Override
@@ -198,8 +212,9 @@ public class EthSignerBaseCommand implements Config {
         .add("logLevel", logLevel)
         .add("downstreamHttpHost", downstreamHttpHost)
         .add("downstreamHttpPort", downstreamHttpPort)
+        .add("downstreamHttpPath", downstreamHttpPath)
+        .add("downstreamHttpReplacePath", downstreamHttpReplacePath)
         .add("downstreamHttpRequestTimeout", downstreamHttpRequestTimeout)
-        .add("downstreamHttpRequestArgs", downstreamHttpRequestArgs)
         .add("httpListenHost", httpListenHost)
         .add("httpListenPort", httpListenPort)
         .add("chainId", chainId)

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -107,6 +107,14 @@ public class EthSignerBaseCommand implements Config {
       arity = "1")
   private String downstreamHttpHost = InetAddress.getLoopbackAddress().getHostAddress();
 
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"--downstream-http-request-args"},
+      description = "Query String to append to the http request (e.g. infura)",
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
+      arity = "1")
+  private String downstreamHttpRequestArgs;
+
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(
       names = "--downstream-http-port",
@@ -141,6 +149,11 @@ public class EthSignerBaseCommand implements Config {
   @Override
   public Integer getDownstreamHttpPort() {
     return downstreamHttpPort;
+  }
+
+  @Override
+  public String getDownstreamHttpRequestArgs() {
+    return downstreamHttpRequestArgs;
   }
 
   @Override
@@ -185,6 +198,7 @@ public class EthSignerBaseCommand implements Config {
         .add("downstreamHttpHost", downstreamHttpHost)
         .add("downstreamHttpPort", downstreamHttpPort)
         .add("downstreamHttpRequestTimeout", downstreamHttpRequestTimeout)
+        .add("downstreamHttpRequestArgs", downstreamHttpRequestArgs)
         .add("httpListenHost", httpListenHost)
         .add("httpListenPort", httpListenPort)
         .add("chainId", chainId)

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -17,6 +17,8 @@ public class CmdlineHelpers {
   public static String validBaseCommandOptions() {
     return "--downstream-http-host=8.8.8.8 "
         + "--downstream-http-port=5000 "
+        + "--downstream-http-path=/v3/projectid "
+        + "--downstream-http-replace-path "
         + "--downstream-http-request-timeout=10000 "
         + "--http-listen-port=5001 "
         + "--http-listen-host=localhost "

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -77,6 +77,8 @@ class CommandlineParserTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.INFO);
     assertThat(config.getDownstreamHttpHost()).isEqualTo("8.8.8.8");
     assertThat(config.getDownstreamHttpPort()).isEqualTo(5000);
+    assertThat(config.getDownstreamHttpPath()).isEqualTo("/v3/projectid");
+    assertThat(config.getDownstreamHttpReplacePath()).isTrue();
     assertThat(config.getDownstreamHttpRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     assertThat(config.getHttpListenHost()).isEqualTo("localhost");
     assertThat(config.getHttpListenPort()).isEqualTo(5001);
@@ -160,6 +162,18 @@ class CommandlineParserTest {
   void missingDownstreamPortDefaultsTo8545() {
     missingOptionalParameterIsValidAndMeetsDefault(
         "http-listen-port", config::getHttpListenPort, 8545);
+  }
+
+  @Test
+  void missingDownstreamPathDefaultsToEmptyString() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "downstream-http-path", config::getDownstreamHttpPath, "");
+  }
+
+  @Test
+  void missingDownstreamReplacePathIsFalse() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "downstream-http-replace-path", config::getDownstreamHttpReplacePath, false);
   }
 
   @Test

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/DefaultProxyTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/DefaultProxyTestBase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.jsonrpcproxy;
+
+import java.io.IOException;
+
+import org.web3j.crypto.CipherException;
+
+public class DefaultProxyTestBase extends IntegrationTestBase {
+
+  private String downstreamHttpPath;
+  private boolean downstreamHttpReplacePath;
+
+  public DefaultProxyTestBase(String downstreamHttpPath, boolean downstreamHttpReplacePath)
+      throws IOException, CipherException {
+    this.downstreamHttpPath = downstreamHttpPath;
+    this.downstreamHttpReplacePath = downstreamHttpReplacePath;
+    setupEthSigner();
+  }
+
+  private void setupEthSigner() throws IOException, CipherException {
+    setupEthSigner(DEFAULT_CHAIN_ID, getDownstreamHttpPath(), isDownstreamHttpReplacePath());
+  }
+
+  protected String getDownstreamHttpPath() {
+    return downstreamHttpPath;
+  }
+
+  protected boolean isDownstreamHttpReplacePath() {
+    return downstreamHttpReplacePath;
+  }
+}

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -83,6 +83,8 @@ public class IntegrationTestBase {
   private static final String LOCALHOST = "127.0.0.1";
   public static final long DEFAULT_CHAIN_ID = 9;
   public static final int DEFAULT_ID = 77;
+  public static final String DOWNSTREAM_PATH = "/v3/projectid";
+  public static final boolean DOWNSTREAM_REPLACE_PATH = true;
 
   static final String MALFORMED_JSON = "{Bad Json: {{{}";
 
@@ -104,6 +106,14 @@ public class IntegrationTestBase {
   @TempDir static Path dataPath;
 
   static void setupEthSigner(final long chainId) throws IOException, CipherException {
+    setupEthSigner(chainId, "", false);
+  }
+
+  static void setupEthSigner(
+      final long chainId,
+      final String downstreamHttpRequestPath,
+      final boolean downstreamHttpReplacePath)
+      throws IOException, CipherException {
     clientAndServer = startClientAndServer();
 
     final File keyFile = createKeyFile();
@@ -121,8 +131,6 @@ public class IntegrationTestBase {
     httpServerOptions.setPort(0);
     httpServerOptions.setHost("localhost");
 
-    final String downstreamHttpRequestArgs = "/";
-
     // Force TransactionDeserialisation to fail
     final ObjectMapper jsonObjectMapper = new ObjectMapper();
     jsonObjectMapper.configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true);
@@ -138,7 +146,8 @@ public class IntegrationTestBase {
             httpClientOptions,
             httpServerOptions,
             downstreamTimeout,
-            downstreamHttpRequestArgs,
+            downstreamHttpRequestPath,
+            downstreamHttpReplacePath,
             jsonDecoder,
             dataPath,
             vertx);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -121,6 +121,8 @@ public class IntegrationTestBase {
     httpServerOptions.setPort(0);
     httpServerOptions.setHost("localhost");
 
+    final String downstreamHttpRequestArgs = "/";
+
     // Force TransactionDeserialisation to fail
     final ObjectMapper jsonObjectMapper = new ObjectMapper();
     jsonObjectMapper.configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true);
@@ -136,6 +138,7 @@ public class IntegrationTestBase {
             httpClientOptions,
             httpServerOptions,
             downstreamTimeout,
+            downstreamHttpRequestArgs,
             jsonDecoder,
             dataPath,
             vertx);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -14,20 +14,27 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static java.util.Collections.singletonMap;
 
+import java.io.IOException;
 import java.util.Map;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
 import org.junit.jupiter.api.Test;
+import org.web3j.crypto.CipherException;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.NetVersion;
 
-class ProxyIntegrationTest extends DefaultTestBase {
+abstract class ProxyIntegrationTest extends DefaultProxyTestBase {
   private static final String LOGIN_BODY = "{\"username\":\"username1\",\"password\":\"pegasys\"}";
   private static final String LOGIN_RESPONSE = "{\"token\":\"eyJ0\"}";
   private static final Map<String, String> REQUEST_HEADERS = singletonMap("Accept", "*/*");
   private static final Map<String, String> RESPONSE_HEADERS =
       singletonMap("Content-Type", "Application/Json");
+
+  public ProxyIntegrationTest(String path, boolean replacePath)
+      throws IOException, CipherException {
+    super(path, replacePath);
+  }
 
   @Test
   void requestWithHeadersIsProxied() {
@@ -61,6 +68,14 @@ class ProxyIntegrationTest extends DefaultTestBase {
     verifyEthNodeReceived(ethProtocolVersionRequest);
   }
 
+  private String getPath(String path) {
+    if (isDownstreamHttpReplacePath()) {
+      return getDownstreamHttpPath();
+    } else {
+      return getDownstreamHttpPath() + path;
+    }
+  }
+
   @Test
   void postRequestToNonRootPathIsProxied() {
     setUpEthNodeResponse(
@@ -72,7 +87,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, getPath("/login"));
   }
 
   @Test
@@ -88,7 +103,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, getPath("/login"));
   }
 
   @Test
@@ -102,7 +117,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, getPath("/login"));
   }
 
   @Test
@@ -116,6 +131,6 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, getPath("/login"));
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithPathAndReplaceTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithPathAndReplaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2019 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,13 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner;
+package tech.pegasys.ethsigner.jsonrpcproxy;
 
-public interface DefaultCommandValues {
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
-  String MANDATORY_BOOLEAN_FORMAT_HELP = "<BOOL>";
+import java.io.IOException;
+
+import org.web3j.crypto.CipherException;
+
+class ProxyIntegrationWithPathAndReplaceTest extends ProxyIntegrationTest {
+
+  public ProxyIntegrationWithPathAndReplaceTest() throws IOException, CipherException {
+    super(DOWNSTREAM_PATH, DOWNSTREAM_REPLACE_PATH);
+  }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithPathTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2019 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,13 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner;
+package tech.pegasys.ethsigner.jsonrpcproxy;
 
-public interface DefaultCommandValues {
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
-  String MANDATORY_BOOLEAN_FORMAT_HELP = "<BOOL>";
+import java.io.IOException;
+
+import org.web3j.crypto.CipherException;
+
+class ProxyIntegrationWithPathTest extends ProxyIntegrationTest {
+
+  public ProxyIntegrationWithPathTest() throws IOException, CipherException {
+    super(DOWNSTREAM_PATH, false);
+  }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithoutPathTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationWithoutPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2019 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,13 +10,15 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.ethsigner;
+package tech.pegasys.ethsigner.jsonrpcproxy;
 
-public interface DefaultCommandValues {
-  String MANDATORY_FILE_FORMAT_HELP = "<FILE>";
-  String MANDATORY_PATH_FORMAT_HELP = "<PATH>";
-  String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
-  String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
-  String MANDATORY_LONG_FORMAT_HELP = "<LONG>";
-  String MANDATORY_BOOLEAN_FORMAT_HELP = "<BOOL>";
+import java.io.IOException;
+
+import org.web3j.crypto.CipherException;
+
+class ProxyIntegrationWithoutPathTest extends ProxyIntegrationTest {
+
+  public ProxyIntegrationWithoutPathTest() throws IOException, CipherException {
+    super("", false);
+  }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -79,7 +79,8 @@ public final class EthSigner {
               webClientOptionsFactory.createWebClientOptions(config),
               applyConfigTlsSettingsTo(serverOptions),
               downstreamHttpRequestTimeout,
-              config.getDownstreamHttpRequestArgs(),
+              config.getDownstreamHttpPath(),
+              config.getDownstreamHttpReplacePath(),
               jsonDecoder,
               config.getDataPath(),
               vertx);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -79,6 +79,7 @@ public final class EthSigner {
               webClientOptionsFactory.createWebClientOptions(config),
               applyConfigTlsSettingsTo(serverOptions),
               downstreamHttpRequestTimeout,
+              config.getDownstreamHttpRequestArgs(),
               jsonDecoder,
               config.getDataPath(),
               vertx);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -59,6 +59,7 @@ public class Runner {
   private final TransactionSignerProvider transactionSignerProvider;
   private final HttpClientOptions clientOptions;
   private final Duration httpRequestTimeout;
+  private final String httpRequestArgs;
   private final HttpResponseFactory responseFactory = new HttpResponseFactory();
   private final JsonDecoder jsonDecoder;
   private final Path dataPath;
@@ -71,6 +72,7 @@ public class Runner {
       final HttpClientOptions clientOptions,
       final HttpServerOptions serverOptions,
       final Duration httpRequestTimeout,
+      final String httpRequestArgs,
       final JsonDecoder jsonDecoder,
       final Path dataPath,
       final Vertx vertx) {
@@ -78,6 +80,7 @@ public class Runner {
     this.transactionSignerProvider = transactionSignerProvider;
     this.clientOptions = clientOptions;
     this.httpRequestTimeout = httpRequestTimeout;
+    this.httpRequestArgs = httpRequestArgs;
     this.jsonDecoder = jsonDecoder;
     this.dataPath = dataPath;
     this.vertx = vertx;
@@ -116,7 +119,7 @@ public class Runner {
         .handler(new UpcheckHandler());
 
     final PassThroughHandler passThroughHandler =
-        new PassThroughHandler(downStreamConnection, transmitterFactory);
+        new PassThroughHandler(downStreamConnection, transmitterFactory, httpRequestArgs);
     router.route().handler(BodyHandler.create()).handler(passThroughHandler);
     return router;
   }
@@ -125,7 +128,7 @@ public class Runner {
       final HttpClient downStreamConnection,
       final VertxRequestTransmitterFactory transmitterFactory) {
     final PassThroughHandler defaultHandler =
-        new PassThroughHandler(downStreamConnection, transmitterFactory);
+        new PassThroughHandler(downStreamConnection, transmitterFactory, httpRequestArgs);
 
     final VertxNonceRequestTransmitterFactory nonceRequestTransmitterFactory =
         new VertxNonceRequestTransmitterFactory(
@@ -138,6 +141,7 @@ public class Runner {
         new SendTransactionHandler(
             chainId,
             downStreamConnection,
+            httpRequestArgs,
             transactionSignerProvider,
             transactionFactory,
             transmitterFactory);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -59,7 +59,8 @@ public class Runner {
   private final TransactionSignerProvider transactionSignerProvider;
   private final HttpClientOptions clientOptions;
   private final Duration httpRequestTimeout;
-  private final String httpRequestArgs;
+  private final String httpDownstreamPath;
+  private final boolean httpDownstreamReplacePath;
   private final HttpResponseFactory responseFactory = new HttpResponseFactory();
   private final JsonDecoder jsonDecoder;
   private final Path dataPath;
@@ -72,7 +73,8 @@ public class Runner {
       final HttpClientOptions clientOptions,
       final HttpServerOptions serverOptions,
       final Duration httpRequestTimeout,
-      final String httpRequestArgs,
+      final String httpDownstreamPath,
+      boolean httpDownstreamReplacePath,
       final JsonDecoder jsonDecoder,
       final Path dataPath,
       final Vertx vertx) {
@@ -80,7 +82,8 @@ public class Runner {
     this.transactionSignerProvider = transactionSignerProvider;
     this.clientOptions = clientOptions;
     this.httpRequestTimeout = httpRequestTimeout;
-    this.httpRequestArgs = httpRequestArgs;
+    this.httpDownstreamPath = httpDownstreamPath;
+    this.httpDownstreamReplacePath = httpDownstreamReplacePath;
     this.jsonDecoder = jsonDecoder;
     this.dataPath = dataPath;
     this.vertx = vertx;
@@ -119,7 +122,11 @@ public class Runner {
         .handler(new UpcheckHandler());
 
     final PassThroughHandler passThroughHandler =
-        new PassThroughHandler(downStreamConnection, transmitterFactory, httpRequestArgs);
+        new PassThroughHandler(
+            downStreamConnection,
+            transmitterFactory,
+            httpDownstreamPath,
+            httpDownstreamReplacePath);
     router.route().handler(BodyHandler.create()).handler(passThroughHandler);
     return router;
   }
@@ -128,7 +135,11 @@ public class Runner {
       final HttpClient downStreamConnection,
       final VertxRequestTransmitterFactory transmitterFactory) {
     final PassThroughHandler defaultHandler =
-        new PassThroughHandler(downStreamConnection, transmitterFactory, httpRequestArgs);
+        new PassThroughHandler(
+            downStreamConnection,
+            transmitterFactory,
+            httpDownstreamPath,
+            httpDownstreamReplacePath);
 
     final VertxNonceRequestTransmitterFactory nonceRequestTransmitterFactory =
         new VertxNonceRequestTransmitterFactory(
@@ -141,7 +152,7 @@ public class Runner {
         new SendTransactionHandler(
             chainId,
             downStreamConnection,
-            httpRequestArgs,
+            httpDownstreamPath,
             transactionSignerProvider,
             transactionFactory,
             transmitterFactory);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -143,7 +143,7 @@ public class Runner {
 
     final VertxNonceRequestTransmitterFactory nonceRequestTransmitterFactory =
         new VertxNonceRequestTransmitterFactory(
-            downStreamConnection, jsonDecoder, httpRequestTimeout);
+            downStreamConnection, jsonDecoder, httpRequestTimeout, httpDownstreamPath);
 
     final TransactionFactory transactionFactory =
         new TransactionFactory(jsonDecoder, nonceRequestTransmitterFactory);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -31,6 +31,8 @@ public interface Config {
 
   Duration getDownstreamHttpRequestTimeout();
 
+  String getDownstreamHttpRequestArgs();
+
   String getHttpListenHost();
 
   Integer getHttpListenPort();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -29,9 +29,11 @@ public interface Config {
 
   Integer getDownstreamHttpPort();
 
-  Duration getDownstreamHttpRequestTimeout();
+  String getDownstreamHttpPath();
 
-  String getDownstreamHttpRequestArgs();
+  boolean getDownstreamHttpReplacePath();
+
+  Duration getDownstreamHttpRequestTimeout();
 
   String getHttpListenHost();
 

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
@@ -51,7 +51,7 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
   }
 
   @Override
-  public void handle(final RoutingContext context) {    
+  public void handle(final RoutingContext context) {
     final HttpServerRequest httpServerRequest = context.request();
     final String uri = httpRequestArgs.equals("/") ? httpServerRequest.uri() : httpRequestArgs;
     final HttpClientRequest proxyRequest =

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
@@ -51,12 +51,13 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
   }
 
   @Override
-  public void handle(final RoutingContext context) {
+  public void handle(final RoutingContext context) {    
     final HttpServerRequest httpServerRequest = context.request();
+    final String uri = httpRequestArgs.equals("/") ? httpServerRequest.uri() : httpRequestArgs;
     final HttpClientRequest proxyRequest =
         ethNodeClient.request(
             httpServerRequest.method(),
-            httpRequestArgs,
+            uri,
             response -> transmitter.handleResponse(context, response));
 
     final Buffer body = context.getBody();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
@@ -53,7 +53,6 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
   @Override
   public void handle(final RoutingContext context) {
     final HttpServerRequest httpServerRequest = context.request();
-    LOG.debug(httpRequestArgs);
     final HttpClientRequest proxyRequest =
         ethNodeClient.request(
             httpServerRequest.method(),

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
@@ -33,12 +33,15 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
 
   private final HttpClient ethNodeClient;
   private final VertxRequestTransmitter transmitter;
+  private final String httpRequestArgs;
 
   public PassThroughHandler(
       final HttpClient ethNodeClient,
-      final VertxRequestTransmitterFactory vertxTransmitterFactory) {
+      final VertxRequestTransmitterFactory vertxTransmitterFactory,
+      final String httpRequestArgs) {
     transmitter = vertxTransmitterFactory.create(this::handleResponseBody);
     this.ethNodeClient = ethNodeClient;
+    this.httpRequestArgs = httpRequestArgs;
   }
 
   @Override
@@ -50,10 +53,11 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
   @Override
   public void handle(final RoutingContext context) {
     final HttpServerRequest httpServerRequest = context.request();
+    LOG.debug(httpRequestArgs);
     final HttpClientRequest proxyRequest =
         ethNodeClient.request(
             httpServerRequest.method(),
-            httpServerRequest.uri(),
+            httpRequestArgs,
             response -> transmitter.handleResponse(context, response));
 
     final Buffer body = context.getBody();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanism.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanism.java
@@ -12,7 +12,8 @@
  */
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction;
 
-import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError;
+import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.NONCE_TOO_LOW;
+
 import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcErrorResponse;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -34,7 +35,7 @@ public class NonceTooLowRetryMechanism extends RetryMechanism {
   public boolean responseRequiresRetry(final HttpClientResponse response, final Buffer body) {
     if ((response.statusCode() == HttpResponseStatus.BAD_REQUEST.code())) {
       final JsonRpcErrorResponse errorResponse = specialiseResponse(body);
-      if (errorResponse.getError().equals(JsonRpcError.NONCE_TOO_LOW)) {
+      if (NONCE_TOO_LOW.equals(errorResponse.getError())) {
         LOG.info("Nonce too low, resend required for {}.", errorResponse.getId());
         return true;
       }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
@@ -32,13 +32,19 @@ public class RetryingTransactionTransmitter extends TransactionTransmitter {
 
   public RetryingTransactionTransmitter(
       final HttpClient ethNodeClient,
+      final String httpRequestArgs,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
       final RetryMechanism retryMechanism,
       final RoutingContext routingContext) {
     super(
-        ethNodeClient, transaction, transactionSerializer, vertxTransmitterFactory, routingContext);
+        ethNodeClient,
+        httpRequestArgs,
+        transaction,
+        transactionSerializer,
+        vertxTransmitterFactory,
+        routingContext);
 
     this.retryMechanism = retryMechanism;
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
@@ -32,7 +32,7 @@ public class RetryingTransactionTransmitter extends TransactionTransmitter {
 
   public RetryingTransactionTransmitter(
       final HttpClient ethNodeClient,
-      final String httpRequestArgs,
+      final String httpPath,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
@@ -40,7 +40,7 @@ public class RetryingTransactionTransmitter extends TransactionTransmitter {
       final RoutingContext routingContext) {
     super(
         ethNodeClient,
-        httpRequestArgs,
+        httpPath,
         transaction,
         transactionSerializer,
         vertxTransmitterFactory,

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -50,13 +50,13 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
   public SendTransactionHandler(
       final long chainId,
       final HttpClient ethNodeClient,
-      final String httpRequestArgs,
+      final String httpPath,
       final TransactionSignerProvider transactionSignerProvider,
       final TransactionFactory transactionFactory,
       final VertxRequestTransmitterFactory vertxTransmitterFactory) {
     this.chainId = chainId;
     this.ethNodeClient = ethNodeClient;
-    this.httpRequestArgs = httpRequestArgs;
+    this.httpRequestArgs = httpPath;
     this.transactionSignerProvider = transactionSignerProvider;
     this.transactionFactory = transactionFactory;
     this.vertxTransmitterFactory = vertxTransmitterFactory;

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -40,6 +40,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
 
   private final long chainId;
   private final HttpClient ethNodeClient;
+  private final String httpRequestArgs;
   private final TransactionSignerProvider transactionSignerProvider;
   private final TransactionFactory transactionFactory;
   private final VertxRequestTransmitterFactory vertxTransmitterFactory;
@@ -49,11 +50,13 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
   public SendTransactionHandler(
       final long chainId,
       final HttpClient ethNodeClient,
+      final String httpRequestArgs,
       final TransactionSignerProvider transactionSignerProvider,
       final TransactionFactory transactionFactory,
       final VertxRequestTransmitterFactory vertxTransmitterFactory) {
     this.chainId = chainId;
     this.ethNodeClient = ethNodeClient;
+    this.httpRequestArgs = httpRequestArgs;
     this.transactionSignerProvider = transactionSignerProvider;
     this.transactionFactory = transactionFactory;
     this.vertxTransmitterFactory = vertxTransmitterFactory;
@@ -110,6 +113,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       LOG.debug("Nonce not present in request {}", request.getId());
       return new RetryingTransactionTransmitter(
           ethNodeClient,
+          httpRequestArgs,
           transaction,
           transactionSerializer,
           vertxTransmitterFactory,
@@ -119,6 +123,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       LOG.debug("Nonce supplied by client, forwarding request");
       return new TransactionTransmitter(
           ethNodeClient,
+          httpRequestArgs,
           transaction,
           transactionSerializer,
           vertxTransmitterFactory,

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
@@ -52,15 +52,18 @@ public class TransactionTransmitter {
   private final Transaction transaction;
   private final VertxRequestTransmitter transmitter;
   private final RoutingContext routingContext;
+  private final String httpRequestArgs;
 
   public TransactionTransmitter(
       final HttpClient ethNodeClient,
+      final String httpRequestArgs,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
       final RoutingContext routingContext) {
     this.transmitter = vertxTransmitterFactory.create(this::handleResponseBody);
     this.ethNodeClient = ethNodeClient;
+    this.httpRequestArgs = httpRequestArgs;
     this.transaction = transaction;
     this.transactionSerializer = transactionSerializer;
     this.routingContext = routingContext;
@@ -131,7 +134,8 @@ public class TransactionTransmitter {
 
   private void sendTransaction(final Buffer bodyContent) {
     final HttpClientRequest request =
-        ethNodeClient.post("/", response -> transmitter.handleResponse(routingContext, response));
+        ethNodeClient.post(
+            httpRequestArgs, response -> transmitter.handleResponse(routingContext, response));
 
     transmitter.sendRequest(request, bodyContent, routingContext);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
@@ -63,7 +63,11 @@ public class TransactionTransmitter {
       final RoutingContext routingContext) {
     this.transmitter = vertxTransmitterFactory.create(this::handleResponseBody);
     this.ethNodeClient = ethNodeClient;
-    this.httpPath = httpPath;
+    if (httpPath == null || "".equals(httpPath.trim())) {
+      this.httpPath = "/"; // default is /
+    } else {
+      this.httpPath = httpPath;
+    }
     this.transaction = transaction;
     this.transactionSerializer = transactionSerializer;
     this.routingContext = routingContext;

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
@@ -52,18 +52,18 @@ public class TransactionTransmitter {
   private final Transaction transaction;
   private final VertxRequestTransmitter transmitter;
   private final RoutingContext routingContext;
-  private final String httpRequestArgs;
+  private final String httpPath;
 
   public TransactionTransmitter(
       final HttpClient ethNodeClient,
-      final String httpRequestArgs,
+      final String httpPath,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
       final RoutingContext routingContext) {
     this.transmitter = vertxTransmitterFactory.create(this::handleResponseBody);
     this.ethNodeClient = ethNodeClient;
-    this.httpRequestArgs = httpRequestArgs;
+    this.httpPath = httpPath;
     this.transaction = transaction;
     this.transactionSerializer = transactionSerializer;
     this.routingContext = routingContext;
@@ -135,7 +135,7 @@ public class TransactionTransmitter {
   private void sendTransaction(final Buffer bodyContent) {
     final HttpClientRequest request =
         ethNodeClient.post(
-            httpRequestArgs, response -> transmitter.handleResponse(routingContext, response));
+            httpPath, response -> transmitter.handleResponse(routingContext, response));
 
     transmitter.sendRequest(request, bodyContent, routingContext);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitter.java
@@ -46,16 +46,23 @@ public class VertxNonceRequestTransmitter {
   private final JsonDecoder decoder;
   private final Duration requestTimeout;
   private static final AtomicInteger nextId = new AtomicInteger(0);
+  private final String httpPath;
 
   public VertxNonceRequestTransmitter(
       final MultiMap headers,
       final HttpClient client,
       final JsonDecoder decoder,
-      final Duration requestTimeout) {
+      final Duration requestTimeout,
+      final String httpPath) {
     this.headers = headers;
     this.client = client;
     this.decoder = decoder;
     this.requestTimeout = requestTimeout;
+    if (httpPath == null || "".equals(httpPath.trim())) {
+      this.httpPath = "/"; // the default path is /
+    } else {
+      this.httpPath = httpPath;
+    }
   }
 
   public BigInteger requestNonce(final JsonRpcRequest request) {
@@ -80,7 +87,7 @@ public class VertxNonceRequestTransmitter {
     final HttpClientRequest request =
         client.request(
             HttpMethod.POST,
-            "/",
+            httpPath,
             response -> response.bodyHandler(responseBody -> handleResponse(responseBody, result)));
 
     request.setTimeout(requestTimeout.toMillis());

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitterFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitterFactory.java
@@ -24,15 +24,20 @@ public class VertxNonceRequestTransmitterFactory {
   private final HttpClient client;
   private final JsonDecoder decoder;
   private final Duration requestTimeout;
+  private final String httpPath;
 
   public VertxNonceRequestTransmitterFactory(
-      final HttpClient client, final JsonDecoder decoder, final Duration requestTimeout) {
+      final HttpClient client,
+      final JsonDecoder decoder,
+      final Duration requestTimeout,
+      final String httpPath) {
     this.client = client;
     this.decoder = decoder;
     this.requestTimeout = requestTimeout;
+    this.httpPath = httpPath;
   }
 
   public VertxNonceRequestTransmitter create(final MultiMap headers) {
-    return new VertxNonceRequestTransmitter(headers, client, decoder, requestTimeout);
+    return new VertxNonceRequestTransmitter(headers, client, decoder, requestTimeout, httpPath);
   }
 }

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanismTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/NonceTooLowRetryMechanismTest.java
@@ -24,6 +24,7 @@ import java.math.BigInteger;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,23 @@ public class NonceTooLowRetryMechanismTest {
 
     final JsonRpcErrorResponse errorResponse =
         new JsonRpcErrorResponse(JsonRpcError.INVALID_PARAMS);
+
+    assertThat(
+            retryMechanism.responseRequiresRetry(httpResponse, Json.encodeToBuffer(errorResponse)))
+        .isFalse();
+  }
+
+  @Test
+  public void retryIsNotRequiredForUnknownErrorType() {
+    when(httpResponse.statusCode()).thenReturn(HttpResponseStatus.BAD_REQUEST.code());
+
+    final JsonObject errorResponse = new JsonObject();
+    final JsonObject error = new JsonObject();
+    error.put("code", -9000);
+    error.put("message", "Unknown error");
+    errorResponse.put("jsonrpc", "2.0");
+    errorResponse.put("id", 1);
+    errorResponse.put("error", new JsonObject());
 
     assertThat(
             retryMechanism.responseRequiresRetry(httpResponse, Json.encodeToBuffer(errorResponse)))


### PR DESCRIPTION
This PR adds a downstream-http-request-args option that replaces all downstream URL requests with the infura URL (including the project id). If this argument is not specified the solution defaults to / which is the current expected functionality.