### PR TITLE
EthSigner to use downstream http path

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -139,7 +139,7 @@ public class EthSignerBaseCommand implements Config {
         throw new ParameterException(
             spec.commandLine(), "Illegal characters detected in --downstream-http-path");
       }
-    } catch (URISyntaxException e) {
+    } catch (final URISyntaxException e) {
       throw new ParameterException(
           spec.commandLine(), "Illegal characters detected in --downstream-http-path");
     }

--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -27,6 +27,8 @@ import tech.pegasys.ethsigner.core.signing.ChainIdProvider;
 import tech.pegasys.ethsigner.core.signing.ConfigurationChainId;
 
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
@@ -36,7 +38,10 @@ import org.apache.logging.log4j.Level;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
+import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.Spec;
 
 @SuppressWarnings("FieldCanBeLocal") // because Picocli injected fields report false positives
 @Command(
@@ -56,6 +61,8 @@ import picocli.CommandLine.Option;
     subcommands = {HelpCommand.class},
     footer = "EthSigner is licensed under the Apache License 2.0")
 public class EthSignerBaseCommand implements Config {
+
+  @Spec private CommandSpec spec; // injected by picocli
 
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
@@ -116,6 +123,29 @@ public class EthSignerBaseCommand implements Config {
       arity = "1")
   private Integer downstreamHttpPort;
 
+  private String downstreamHttpPath = "/";
+
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"--downstream-http-path"},
+      description = "The path to which received requests are forwarded (default: ${DEFAULT-VALUE})",
+      defaultValue = "/",
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
+      arity = "1")
+  public void setDownstreamHttpPath(final String path) {
+    try {
+      final URI uri = new URI(path);
+      if (!uri.getPath().equals(path)) {
+        throw new ParameterException(
+            spec.commandLine(), "Illegal characters detected in --downstream-http-path");
+      }
+    } catch (URISyntaxException e) {
+      throw new ParameterException(
+          spec.commandLine(), "Illegal characters detected in --downstream-http-path");
+    }
+    this.downstreamHttpPath = path;
+  }
+
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"--downstream-http-request-timeout"},
@@ -141,6 +171,11 @@ public class EthSignerBaseCommand implements Config {
   @Override
   public Integer getDownstreamHttpPort() {
     return downstreamHttpPort;
+  }
+
+  @Override
+  public String getDownstreamHttpPath() {
+    return downstreamHttpPath;
   }
 
   @Override
@@ -184,6 +219,7 @@ public class EthSignerBaseCommand implements Config {
         .add("logLevel", logLevel)
         .add("downstreamHttpHost", downstreamHttpHost)
         .add("downstreamHttpPort", downstreamHttpPort)
+        .add("downstreamHttpPath", downstreamHttpPath)
         .add("downstreamHttpRequestTimeout", downstreamHttpRequestTimeout)
         .add("httpListenHost", httpListenHost)
         .add("httpListenPort", httpListenPort)

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -17,6 +17,7 @@ public class CmdlineHelpers {
   public static String validBaseCommandOptions() {
     return "--downstream-http-host=8.8.8.8 "
         + "--downstream-http-port=5000 "
+        + "--downstream-http-path=/v3/projectid "
         + "--downstream-http-request-timeout=10000 "
         + "--http-listen-port=5001 "
         + "--http-listen-host=localhost "

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -34,6 +34,8 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import picocli.CommandLine;
 
 class CommandlineParserTest {
@@ -77,6 +79,7 @@ class CommandlineParserTest {
     assertThat(config.getLogLevel()).isEqualTo(Level.INFO);
     assertThat(config.getDownstreamHttpHost()).isEqualTo("8.8.8.8");
     assertThat(config.getDownstreamHttpPort()).isEqualTo(5000);
+    assertThat(config.getDownstreamHttpPath()).isEqualTo("/v3/projectid");
     assertThat(config.getDownstreamHttpRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     assertThat(config.getHttpListenHost()).isEqualTo("localhost");
     assertThat(config.getHttpListenPort()).isEqualTo(5001);
@@ -160,6 +163,12 @@ class CommandlineParserTest {
   void missingDownstreamPortDefaultsTo8545() {
     missingOptionalParameterIsValidAndMeetsDefault(
         "http-listen-port", config::getHttpListenPort, 8545);
+  }
+
+  @Test
+  void missingDownstreamPathDefaultsToRootPath() {
+    missingOptionalParameterIsValidAndMeetsDefault(
+        "downstream-http-path", config::getDownstreamHttpPath, "/");
   }
 
   @Test
@@ -334,5 +343,16 @@ class CommandlineParserTest {
 
     assertThat(result).isTrue();
     assertThat(config.getTlsOptions()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"=", " ", "&", "?", "#"})
+  void illegalDownStreamPathThrowsException(String illegalChar) {
+    String cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldFrom(cmdLine, "downstream-http-path");
+    cmdLine += " --downstream-http-path=path1/" + illegalChar + "path2";
+    final boolean result =
+        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    assertThat(result).isFalse();
   }
 }

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -347,7 +347,7 @@ class CommandlineParserTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"=", " ", "&", "?", "#"})
-  void illegalDownStreamPathThrowsException(String illegalChar) {
+  void illegalDownStreamPathThrowsException(final String illegalChar) {
     String cmdLine = validBaseCommandOptions();
     cmdLine = removeFieldFrom(cmdLine, "downstream-http-path");
     cmdLine += " --downstream-http-path=path1/" + illegalChar + "path2";

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -51,8 +51,11 @@ dependencies {
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
+
+
   integrationTestImplementation project(':ethsigner:signer:file-based')
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-params'
   integrationTestImplementation 'io.rest-assured:rest-assured'
   integrationTestImplementation 'org.assertj:assertj-core'
   integrationTestImplementation('org.mock-server:mockserver-netty') {

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -26,6 +26,7 @@ import static org.web3j.utils.Async.defaultExecutorService;
 
 import tech.pegasys.ethsigner.core.Runner;
 import tech.pegasys.ethsigner.core.jsonrpc.JsonDecoder;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.DownstreamPathCalculator;
 import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
 import tech.pegasys.ethsigner.core.signing.TransactionSigner;
 import tech.pegasys.ethsigner.core.signing.TransactionSignerProvider;
@@ -104,6 +105,11 @@ public class IntegrationTestBase {
   @TempDir static Path dataPath;
 
   static void setupEthSigner(final long chainId) throws IOException, CipherException {
+    setupEthSigner(chainId, "");
+  }
+
+  static void setupEthSigner(final long chainId, final String downstreamHttpRequestPath)
+      throws IOException, CipherException {
     clientAndServer = startClientAndServer();
 
     final File keyFile = createKeyFile();
@@ -136,6 +142,7 @@ public class IntegrationTestBase {
             httpClientOptions,
             httpServerOptions,
             downstreamTimeout,
+            new DownstreamPathCalculator(downstreamHttpRequestPath),
             jsonDecoder,
             dataPath,
             vertx);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 import static java.util.Collections.singletonMap;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Map;
 
 import io.netty.handler.codec.http.HttpResponseStatus;

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -14,24 +14,40 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static java.util.Collections.singletonMap;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.web3j.crypto.CipherException;
 import org.web3j.protocol.core.Response;
 import org.web3j.protocol.core.methods.response.NetVersion;
 
-class ProxyIntegrationTest extends DefaultTestBase {
+public class ProxyIntegrationTest extends IntegrationTestBase {
   private static final String LOGIN_BODY = "{\"username\":\"username1\",\"password\":\"pegasys\"}";
   private static final String LOGIN_RESPONSE = "{\"token\":\"eyJ0\"}";
   private static final Map<String, String> REQUEST_HEADERS = singletonMap("Accept", "*/*");
   private static final Map<String, String> RESPONSE_HEADERS =
       singletonMap("Content-Type", "Application/Json");
 
+  private static final String ROOT_PATH = "/arbitraryRootPath";
+
+  @BeforeAll
+  public static void localSetup() {
+    try {
+      setupEthSigner(DEFAULT_CHAIN_ID, ROOT_PATH);
+    } catch (final CipherException | IOException e) {
+      throw new RuntimeException("Failed to setup ethsigner");
+    }
+  }
+
   @Test
   void requestWithHeadersIsProxied() {
     final String netVersionRequest = Json.encode(jsonRpc().netVersion());
+
     final Response<String> netVersion = new NetVersion();
     netVersion.setResult("4");
     final String netVersionResponse = Json.encode(netVersion);
@@ -72,7 +88,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, Path.of("/", ROOT_PATH, "login").toString());
   }
 
   @Test
@@ -88,7 +104,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, ROOT_PATH + "/login");
   }
 
   @Test
@@ -102,7 +118,7 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, ROOT_PATH + "/login");
   }
 
   @Test
@@ -116,6 +132,6 @@ class ProxyIntegrationTest extends DefaultTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, "/login");
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, ROOT_PATH + "/login");
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -88,7 +88,7 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
         response.ethSigner(RESPONSE_HEADERS, LOGIN_RESPONSE),
         "/login");
 
-    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, Path.of("/", ROOT_PATH, "login").toString());
+    verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, ROOT_PATH + "/login");
   }
 
   @Test

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -16,6 +16,7 @@ import tech.pegasys.ethsigner.core.config.ClientAuthConstraints;
 import tech.pegasys.ethsigner.core.config.Config;
 import tech.pegasys.ethsigner.core.config.TlsOptions;
 import tech.pegasys.ethsigner.core.jsonrpc.JsonDecoder;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.DownstreamPathCalculator;
 import tech.pegasys.ethsigner.core.signing.TransactionSignerProvider;
 import tech.pegasys.ethsigner.core.util.FileUtil;
 
@@ -79,6 +80,7 @@ public final class EthSigner {
               webClientOptionsFactory.createWebClientOptions(config),
               applyConfigTlsSettingsTo(serverOptions),
               downstreamHttpRequestTimeout,
+              new DownstreamPathCalculator(config.getDownstreamHttpPath()),
               jsonDecoder,
               config.getDataPath(),
               vertx);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -29,6 +29,8 @@ public interface Config {
 
   Integer getDownstreamHttpPort();
 
+  String getDownstreamHttpPath();
+
   Duration getDownstreamHttpRequestTimeout();
 
   String getHttpListenHost();

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/DownstreamPathCalculator.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/DownstreamPathCalculator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core.requesthandler.sendtransaction;
+
+public class DownstreamPathCalculator {
+
+  private final String httpDownstreamPathPrefix;
+
+  public DownstreamPathCalculator(final String httpDownstreamPathPrefix) {
+    this.httpDownstreamPathPrefix = httpDownstreamPathPrefix;
+  }
+
+  public String calculateDownstreamPath(final String receivedRequestUri) {
+    // This function is required to join httpDownStreamPathPrefix with receivedRequestURI
+    // remove any duplicate "/"
+    // Not have an ending "/" if the path
+    // assumes httpdownstreamPathPrefix does not include =,?,&
+    // has a leading "/" as required by vertx
+    String result = "/" + httpDownstreamPathPrefix + "/" + receivedRequestUri;
+    result = result.replaceAll("/+", "/");
+    return result.length() == 1 ? result : result.replaceAll("/$", "");
+  }
+}

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/RetryingTransactionTransmitter.java
@@ -32,13 +32,19 @@ public class RetryingTransactionTransmitter extends TransactionTransmitter {
 
   public RetryingTransactionTransmitter(
       final HttpClient ethNodeClient,
+      final String httpPath,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
       final RetryMechanism retryMechanism,
       final RoutingContext routingContext) {
     super(
-        ethNodeClient, transaction, transactionSerializer, vertxTransmitterFactory, routingContext);
+        ethNodeClient,
+        httpPath,
+        transaction,
+        transactionSerializer,
+        vertxTransmitterFactory,
+        routingContext);
 
     this.retryMechanism = retryMechanism;
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -40,6 +40,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
 
   private final long chainId;
   private final HttpClient ethNodeClient;
+  private final DownstreamPathCalculator downstreamPathCalculator;
   private final TransactionSignerProvider transactionSignerProvider;
   private final TransactionFactory transactionFactory;
   private final VertxRequestTransmitterFactory vertxTransmitterFactory;
@@ -49,11 +50,13 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
   public SendTransactionHandler(
       final long chainId,
       final HttpClient ethNodeClient,
+      final DownstreamPathCalculator downstreamPathCalculator,
       final TransactionSignerProvider transactionSignerProvider,
       final TransactionFactory transactionFactory,
       final VertxRequestTransmitterFactory vertxTransmitterFactory) {
     this.chainId = chainId;
     this.ethNodeClient = ethNodeClient;
+    this.downstreamPathCalculator = downstreamPathCalculator;
     this.transactionSignerProvider = transactionSignerProvider;
     this.transactionFactory = transactionFactory;
     this.vertxTransmitterFactory = vertxTransmitterFactory;
@@ -110,6 +113,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       LOG.debug("Nonce not present in request {}", request.getId());
       return new RetryingTransactionTransmitter(
           ethNodeClient,
+          downstreamPathCalculator.calculateDownstreamPath(routingContext.request().uri()),
           transaction,
           transactionSerializer,
           vertxTransmitterFactory,
@@ -119,6 +123,7 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       LOG.debug("Nonce supplied by client, forwarding request");
       return new TransactionTransmitter(
           ethNodeClient,
+          downstreamPathCalculator.calculateDownstreamPath(routingContext.request().uri()),
           transaction,
           transactionSerializer,
           vertxTransmitterFactory,

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
@@ -52,15 +52,18 @@ public class TransactionTransmitter {
   private final Transaction transaction;
   private final VertxRequestTransmitter transmitter;
   private final RoutingContext routingContext;
+  private final String downstreamPath;
 
   public TransactionTransmitter(
       final HttpClient ethNodeClient,
+      final String downstreamPath,
       final Transaction transaction,
       final TransactionSerializer transactionSerializer,
       final VertxRequestTransmitterFactory vertxTransmitterFactory,
       final RoutingContext routingContext) {
     this.transmitter = vertxTransmitterFactory.create(this::handleResponseBody);
     this.ethNodeClient = ethNodeClient;
+    this.downstreamPath = downstreamPath;
     this.transaction = transaction;
     this.transactionSerializer = transactionSerializer;
     this.routingContext = routingContext;
@@ -131,7 +134,8 @@ public class TransactionTransmitter {
 
   private void sendTransaction(final Buffer bodyContent) {
     final HttpClientRequest request =
-        ethNodeClient.post("/", response -> transmitter.handleResponse(routingContext, response));
+        ethNodeClient.post(
+            downstreamPath, response -> transmitter.handleResponse(routingContext, response));
 
     transmitter.sendRequest(request, bodyContent, routingContext);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitter.java
@@ -18,6 +18,7 @@ import tech.pegasys.ethsigner.core.jsonrpc.JsonDecoder;
 import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequestId;
 import tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcSuccessResponse;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.DownstreamPathCalculator;
 
 import java.math.BigInteger;
 import java.time.Duration;
@@ -46,16 +47,19 @@ public class VertxNonceRequestTransmitter {
   private final JsonDecoder decoder;
   private final Duration requestTimeout;
   private static final AtomicInteger nextId = new AtomicInteger(0);
+  private final DownstreamPathCalculator downstreamPathCalculator;
 
   public VertxNonceRequestTransmitter(
       final MultiMap headers,
       final HttpClient client,
       final JsonDecoder decoder,
-      final Duration requestTimeout) {
+      final Duration requestTimeout,
+      final DownstreamPathCalculator downstreamPathCalculator) {
     this.headers = headers;
     this.client = client;
     this.decoder = decoder;
     this.requestTimeout = requestTimeout;
+    this.downstreamPathCalculator = downstreamPathCalculator;
   }
 
   public BigInteger requestNonce(final JsonRpcRequest request) {
@@ -80,7 +84,7 @@ public class VertxNonceRequestTransmitter {
     final HttpClientRequest request =
         client.request(
             HttpMethod.POST,
-            "/",
+            downstreamPathCalculator.calculateDownstreamPath("/"),
             response -> response.bodyHandler(responseBody -> handleResponse(responseBody, result)));
 
     request.setTimeout(requestTimeout.toMillis());

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitterFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/VertxNonceRequestTransmitterFactory.java
@@ -13,6 +13,7 @@
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction;
 
 import tech.pegasys.ethsigner.core.jsonrpc.JsonDecoder;
+import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.DownstreamPathCalculator;
 
 import java.time.Duration;
 
@@ -24,15 +25,21 @@ public class VertxNonceRequestTransmitterFactory {
   private final HttpClient client;
   private final JsonDecoder decoder;
   private final Duration requestTimeout;
+  private final DownstreamPathCalculator downstreamPathCalculator;
 
   public VertxNonceRequestTransmitterFactory(
-      final HttpClient client, final JsonDecoder decoder, final Duration requestTimeout) {
+      final HttpClient client,
+      final JsonDecoder decoder,
+      final Duration requestTimeout,
+      final DownstreamPathCalculator downstreamPathCalculator) {
     this.client = client;
     this.decoder = decoder;
     this.requestTimeout = requestTimeout;
+    this.downstreamPathCalculator = downstreamPathCalculator;
   }
 
   public VertxNonceRequestTransmitter create(final MultiMap headers) {
-    return new VertxNonceRequestTransmitter(headers, client, decoder, requestTimeout);
+    return new VertxNonceRequestTransmitter(
+        headers, client, decoder, requestTimeout, downstreamPathCalculator);
   }
 }

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/DownstreamPathCalculatorTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/DownstreamPathCalculatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core.requesthandler.sendtransaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DownstreamPathCalculatorTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rootPath/child", "/rootPath/child", "/rootPath/child/"})
+  void variousPathPrefixesResolveToTheSameDownstreamEndpoint(final String httpDownstreamPath) {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator(httpDownstreamPath);
+    final String result = calc.calculateDownstreamPath("/login");
+    assertThat(result).isEqualTo("/rootPath/child/login");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"rootPath/child", "/rootPath/child", "/rootPath/child/"})
+  void variousPathPrefixesResolveToTheSameDownstreamEndpointWithNoSlashOnReceivedUri(
+      final String httpDownstreamPath) {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator(httpDownstreamPath);
+    final String result = calc.calculateDownstreamPath("login");
+    assertThat(result).isEqualTo("/rootPath/child/login");
+  }
+
+  @Test
+  void blankRequestUriProducesAbsolutePathOfPrefix() {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator("prefix");
+    final String result = calc.calculateDownstreamPath("");
+    assertThat(result).isEqualTo("/prefix");
+  }
+
+  @Test
+  void slashRequestUriProducesAbsolutePathOfPrefix() {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator("prefix");
+    final String result = calc.calculateDownstreamPath("/");
+    assertThat(result).isEqualTo("/prefix");
+  }
+
+  @Test
+  void slashPrefixWithNoUriResultsInDownstreamOfJustSlash() {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator("/");
+    final String result = calc.calculateDownstreamPath("/");
+    assertThat(result).isEqualTo("/");
+  }
+
+  @Test
+  void emptyRootPathIsReplacedWithSlash() {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator("");
+    final String result = calc.calculateDownstreamPath("arbitraryPath");
+    assertThat(result).isEqualTo("/arbitraryPath");
+  }
+
+  @Test
+  void multipleSlashInRootAreDiscarded() {
+    final DownstreamPathCalculator calc = new DownstreamPathCalculator("////");
+    final String result = calc.calculateDownstreamPath("arbitraryPath");
+    assertThat(result).isEqualTo("/arbitraryPath");
+  }
+}


### PR DESCRIPTION
There are times that the downstream web3 provider may not be available on the root path ("/") - but rather may be 'mounted' at a different location on the server.

As such, to access the web3 provider a path is required, above and beyond the host and port.

This change adds such path to the cli, and drills it down into all http client transmissions.

This work was originally contributed by github user sprect8 (https://github.com/sprect8) in https://github.com/PegaSysEng/ethsigner/pull/258; this constitutes a minor refactoring.