### PR TITLE
Remove azure tests Circle CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,27 +128,6 @@ jobs:
       - notify            
       - capture_test_results
 
-  azureTests:
-    executor: executor_machine
-    steps:
-      - prepare
-      - run:
-          name: Install Packages - Java 11
-          command: |
-            sudo rm  /etc/apt/sources.list.d/google-chrome.list*
-            sudo rm  /etc/apt/sources.list.d/heroku.list*
-            sudo add-apt-repository -y ppa:openjdk-r/ppa
-            sudo apt update
-            sudo apt install -y openjdk-11-jdk
-            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
-      - run:
-          name: Azure tests
-          command: |
-            ./gradlew --no-daemon --parallel :ethsigner:signer:azure:test
-            ./gradlew --no-daemon --parallel acceptanceTest --tests *Azure*
-      - notify            
-      - capture_test_results
-
   buildDocker:
     executor: executor_med
     steps:
@@ -212,21 +191,10 @@ workflows:
       - acceptanceTests:
           requires:
             - build
-      - azureTests:
-          requires:
-            - build
   default:
     jobs:
       - build
       - acceptanceTests:
-          requires:
-            - build
-      - azureTests:
-          filters:
-            branches:
-              only:
-                - master
-                - /^release-.*/
           requires:
             - build
       - buildDocker:
@@ -241,7 +209,6 @@ workflows:
           requires:
             - build
             - acceptanceTests
-            - azureTests
       - publishDocker:
           filters:
             branches:
@@ -251,5 +218,4 @@ workflows:
           requires:
             - build
             - acceptanceTests
-            - azureTests
             - buildDocker


### PR DESCRIPTION
Remove the azure tests Circle CI job. These tests are now being run as part of the main build so this job is no longer necessary.