### PR TITLE
Update signers library

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   testRuntimeOnly 'org.bouncycastle:bcpkix-jdk15on'
 
   testImplementation project(':ethsigner:core')
-  testImplementation (group: 'tech.pegasys.signers.internal', name: 'signing-secp256k1-common', classifier: 'test-fixtures')
+  testImplementation (group: 'tech.pegasys.signers.internal', name: 'signing-secp256k1-impl', classifier: 'test-fixtures')
   testImplementation (group: 'tech.pegasys.signers.internal', name: 'keystorage-hashicorp', classifier: 'test-fixtures')
 
   testImplementation 'com.github.docker-java:docker-java'

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,6 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
-    mavenLocal()
     jcenter()
     mavenCentral()
     maven { url "https://consensys.bintray.com/pegasys-repo" }

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ allprojects {
   targetCompatibility = 11
 
   repositories {
+    mavenLocal()
     jcenter()
     mavenCentral()
     maven { url "https://consensys.bintray.com/pegasys-repo" }

--- a/ethsigner/commandline/build.gradle
+++ b/ethsigner/commandline/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
   implementation project(':ethsigner:core')
   implementation 'tech.pegasys.signers.internal:signing-secp256k1-api'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-common'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-impl'
   implementation 'info.picocli:picocli'
   implementation 'com.google.guava:guava'
   implementation 'org.apache.logging.log4j:log4j-api'

--- a/ethsigner/core/build.gradle
+++ b/ethsigner/core/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
 
 
-  integrationTestImplementation 'tech.pegasys.signers.internal:signing-secp256k1-file-based'
+  integrationTestImplementation 'tech.pegasys.signers.internal:signing-secp256k1-impl'
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.junit.jupiter:junit-jupiter-params'
   integrationTestImplementation 'io.rest-assured:rest-assured'

--- a/ethsigner/subcommands/build.gradle
+++ b/ethsigner/subcommands/build.gradle
@@ -17,11 +17,7 @@ dependencies {
   implementation project(':ethsigner:core')
 
   implementation 'tech.pegasys.signers.internal:signing-secp256k1-api'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-common'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-hashicorp'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-file-based'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-multikey'
-  implementation 'tech.pegasys.signers.internal:signing-secp256k1-azure'
+  implementation 'tech.pegasys.signers.internal:signing-secp256k1-impl'
   implementation 'tech.pegasys.signers.internal:keystorage-hashicorp'
 
   implementation 'info.picocli:picocli'

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -69,14 +69,10 @@ dependencyManagement {
     dependency 'org.web3j:core:4.5.14'
     dependency 'org.web3j:crypto:4.5.14'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2-SNAPSHOT') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2-JF-SNAPSHOT') {
       entry 'keystorage-hashicorp'
       entry 'signing-secp256k1-api'
-      entry 'signing-secp256k1-common'
-      entry 'signing-secp256k1-azure'
-      entry 'signing-secp256k1-file-based'
-      entry 'signing-secp256k1-hashicorp'
-      entry 'signing-secp256k1-multikey'
+      entry 'signing-secp256k1-impl'
     }
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -69,7 +69,7 @@ dependencyManagement {
     dependency 'org.web3j:core:4.5.14'
     dependency 'org.web3j:crypto:4.5.14'
 
-    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2-JF-SNAPSHOT') {
+    dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.2-SNAPSHOT') {
       entry 'keystorage-hashicorp'
       entry 'signing-secp256k1-api'
       entry 'signing-secp256k1-impl'


### PR DESCRIPTION
Update to use latest signers library requiring some dependency changes as there are now only two jars the api and impl.