### PR TITLE
Fix requests to web3 provider using virtual hosts

### DIFF
--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -62,6 +62,25 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
+  void requestWithHostHeaderIsRenamedToXForwardedHost() {
+    final String netVersionRequest = Json.encode(jsonRpc().netVersion());
+
+    final Response<String> netVersion = new NetVersion();
+    netVersion.setResult("4");
+    final String netVersionResponse = Json.encode(netVersion);
+
+    setUpEthNodeResponse(
+        request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
+
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(Map.of("Accept", "*/*", "Host", "localhost"), netVersionRequest),
+        response.ethSigner(RESPONSE_HEADERS, netVersionResponse));
+
+    verifyEthNodeReceived(
+        Map.of("Accept", "*/*", "X-Forwarded-Host", "localhost"), netVersionRequest);
+  }
+
+  @Test
   void requestReturningErrorIsProxied() {
     final String ethProtocolVersionRequest = Json.encode(jsonRpc().ethProtocolVersion());
 

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -81,6 +81,27 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
   }
 
   @Test
+  void requestWithHostHeaderOverwritesExistingXForwardedHost() {
+    final String netVersionRequest = Json.encode(jsonRpc().netVersion());
+
+    final Response<String> netVersion = new NetVersion();
+    netVersion.setResult("4");
+    final String netVersionResponse = Json.encode(netVersion);
+
+    setUpEthNodeResponse(
+        request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
+
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(
+            Map.of("Accept", "*/*", "Host", "localhost", "X-Forwarded-Host", "nowhere"),
+            netVersionRequest),
+        response.ethSigner(RESPONSE_HEADERS, netVersionResponse));
+
+    verifyEthNodeReceived(
+        Map.of("Accept", "*/*", "X-Forwarded-Host", "localhost"), netVersionRequest);
+  }
+
+  @Test
   void requestReturningErrorIsProxied() {
     final String ethProtocolVersionRequest = Json.encode(jsonRpc().ethProtocolVersion());
 


### PR DESCRIPTION
Requests were not made to downstream web3 provider when host header required .e.g Infura. The host header was being passed through from the original request to EthSigner this breaks requests to web3 providers that require virtual host support through the host header.

Changes the headers made to web3 provider to
* Remove the original host header and allow Vertx to set this to the correct value
* Set the original host value on a x-forwarded-host header

Fixes https://github.com/PegaSysEng/ethsigner/issues/279

