### PR TITLE
Add CORS headers to requests

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -20,6 +20,7 @@ import static tech.pegasys.ethsigner.DefaultCommandValues.MANDATORY_PORT_FORMAT_
 import tech.pegasys.ethsigner.config.InvalidCommandLineOptionsException;
 import tech.pegasys.ethsigner.config.PicoCliTlsServerOptions;
 import tech.pegasys.ethsigner.config.tls.client.PicoCliClientTlsOptions;
+import tech.pegasys.ethsigner.core.CorsAllowedOriginsProperty;
 import tech.pegasys.ethsigner.core.config.Config;
 import tech.pegasys.ethsigner.core.config.TlsOptions;
 import tech.pegasys.ethsigner.core.config.tls.client.ClientTlsOptions;
@@ -31,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
@@ -146,6 +148,13 @@ public class EthSignerBaseCommand implements Config {
     this.downstreamHttpPath = path;
   }
 
+  // A list of origins URLs that are accepted by the JsonRpcHttpServer (CORS)
+  @Option(
+      names = {"--http-cors-origins"},
+      description = "Comma separated origin domain URLs for CORS validation (default: none)")
+  private final CorsAllowedOriginsProperty rpcHttpCorsAllowedOrigins =
+      new CorsAllowedOriginsProperty();
+
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"--downstream-http-request-timeout"},
@@ -214,6 +223,11 @@ public class EthSignerBaseCommand implements Config {
   }
 
   @Override
+  public Collection<String> getCorsAllowedOrigins() {
+    return rpcHttpCorsAllowedOrigins;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("logLevel", logLevel)
@@ -226,6 +240,7 @@ public class EthSignerBaseCommand implements Config {
         .add("chainId", chainId)
         .add("dataPath", dataPath)
         .add("clientTlsOptions", clientTlsOptions)
+        .add("corsAllowedOrigins", rpcHttpCorsAllowedOrigins)
         .toString();
   }
 

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -12,37 +12,44 @@
  */
 package tech.pegasys.ethsigner;
 
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class CmdlineHelpers {
 
-  public static String validBaseCommandOptions() {
-    return "--downstream-http-host=8.8.8.8 "
-        + "--downstream-http-port=5000 "
-        + "--downstream-http-path=/v3/projectid "
-        + "--downstream-http-request-timeout=10000 "
-        + "--http-listen-port=5001 "
-        + "--http-listen-host=localhost "
-        + "--chain-id=6 "
-        + "--logging=INFO "
-        + "--tls-keystore-file=./keystore.pfx "
-        + "--tls-keystore-password-file=./keystore.passwd "
-        + "--tls-known-clients-file=./known_clients "
-        + "--tls-allow-ca-clients "
-        + "--downstream-http-tls-enabled "
-        + "--downstream-http-tls-keystore-file=./test.ks "
-        + "--downstream-http-tls-keystore-password-file=./test.pass "
-        + "--downstream-http-tls-ca-auth-enabled=false "
-        + "--downstream-http-tls-known-servers-file=./test.txt ";
+  public static List<String> validBaseCommandOptions() {
+    return Lists.newArrayList("--downstream-http-host=8.8.8.8",
+        "--downstream-http-port=5000",
+        "--downstream-http-path=/v3/projectid",
+        "--downstream-http-request-timeout=10000",
+        "--http-listen-port=5001",
+        "--http-listen-host=localhost",
+        "--chain-id=6",
+        "--logging=INFO",
+        "--tls-keystore-file=./keystore.pfx",
+        "--tls-keystore-password-file=./keystore.passwd",
+        "--tls-known-clients-file=./known_clients",
+        "--tls-allow-ca-clients",
+        "--downstream-http-tls-enabled",
+        "--downstream-http-tls-keystore-file=./test.ks",
+        "--downstream-http-tls-keystore-password-file=./test.pass",
+        "--downstream-http-tls-ca-auth-enabled=false",
+        "--downstream-http-tls-known-servers-file=./test.txt");
   }
 
-  public static String removeFieldFrom(final String input, final String... fieldNames) {
-    String updatedInput = input;
-    for (String fieldName : fieldNames) {
-      updatedInput = updatedInput.replaceAll("--" + fieldName + ".*?(\\s|$)", "");
-    }
-    return updatedInput;
+  public static List<String> removeFieldsFrom(final List<String> cmdlineArgs,
+      final String... fieldNames) {
+    final List<String> fieldsToRemove = Lists.newArrayList(fieldNames);
+    return cmdlineArgs.stream().filter(
+        arg -> fieldsToRemove.stream().noneMatch(arg::contains))
+        .collect(Collectors.toList());
   }
 
-  public static String modifyField(final String input, final String fieldName, final String value) {
-    return input.replaceFirst("--" + fieldName + "=[^\\s]*", "--" + fieldName + "=" + value);
+  public static List<String> modifyField(List<String> cmdlineArgs, final String fieldName,
+      final String value) {
+    final String replacement = "--" + fieldName + "=" + value;
+    return cmdlineArgs.stream().map(arg -> arg.contains(fieldName) ? replacement : arg)
+        .collect(Collectors.toList());
   }
 }

--- a/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
+++ b/ethsigner/commandline/src/test-support/java/tech/pegasys/ethsigner/CmdlineHelpers.java
@@ -12,14 +12,16 @@
  */
 package tech.pegasys.ethsigner;
 
-import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
 
 public class CmdlineHelpers {
 
   public static List<String> validBaseCommandOptions() {
-    return Lists.newArrayList("--downstream-http-host=8.8.8.8",
+    return Lists.newArrayList(
+        "--downstream-http-host=8.8.8.8",
         "--downstream-http-port=5000",
         "--downstream-http-path=/v3/projectid",
         "--downstream-http-request-timeout=10000",
@@ -38,18 +40,19 @@ public class CmdlineHelpers {
         "--downstream-http-tls-known-servers-file=./test.txt");
   }
 
-  public static List<String> removeFieldsFrom(final List<String> cmdlineArgs,
-      final String... fieldNames) {
+  public static List<String> removeFieldsFrom(
+      final List<String> cmdlineArgs, final String... fieldNames) {
     final List<String> fieldsToRemove = Lists.newArrayList(fieldNames);
-    return cmdlineArgs.stream().filter(
-        arg -> fieldsToRemove.stream().noneMatch(arg::contains))
+    return cmdlineArgs.stream()
+        .filter(arg -> fieldsToRemove.stream().noneMatch(arg::contains))
         .collect(Collectors.toList());
   }
 
-  public static List<String> modifyField(List<String> cmdlineArgs, final String fieldName,
-      final String value) {
+  public static List<String> modifyField(
+      List<String> cmdlineArgs, final String fieldName, final String value) {
     final String replacement = "--" + fieldName + "=" + value;
-    return cmdlineArgs.stream().map(arg -> arg.contains(fieldName) ? replacement : arg)
+    return cmdlineArgs.stream()
+        .map(arg -> arg.contains(fieldName) ? replacement : arg)
         .collect(Collectors.toList());
   }
 }

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserClientTlsOptionsTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserClientTlsOptionsTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.ethsigner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.CmdlineHelpers.modifyField;
-import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldFrom;
+import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldsFrom;
 import static tech.pegasys.ethsigner.CmdlineHelpers.validBaseCommandOptions;
 import static tech.pegasys.ethsigner.util.CommandLineParserAssertions.parseCommandLineWithMissingParamsShowsError;
 
@@ -60,16 +60,16 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void cmdLineIsValidIfOnlyDownstreamTlsIsEnabled() {
-    final String cmdLine =
-        removeFieldFrom(
+    List<String> cmdLine =
+        removeFieldsFrom(
             validBaseCommandOptions(),
             "downstream-http-tls-keystore-file",
             "downstream-http-tls-keystore-password-file",
             "downstream-http-tls-ca-auth-enabled",
             "downstream-http-tls-known-servers-file");
 
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).as("CLI Parse result").isTrue();
     final Optional<ClientTlsOptions> optionalDownstreamTlsOptions = config.getClientTlsOptions();
@@ -82,17 +82,16 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void cmdLineIsValidWithoutDownstreamTlsOptions() {
-    final String cmdLine =
-        removeFieldFrom(
+    List<String> cmdLine =
+        removeFieldsFrom(
             validBaseCommandOptions(),
             "downstream-http-tls-enabled",
             "downstream-http-tls-keystore-file",
             "downstream-http-tls-keystore-password-file",
             "downstream-http-tls-ca-auth-enabled",
             "downstream-http-tls-known-servers-file");
-
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).as("CLI Parse result").isTrue();
     final Optional<ClientTlsOptions> optionalDownstreamTlsOptions = config.getClientTlsOptions();
@@ -101,10 +100,9 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void cmdLineIsValidWithAllTlsOptions() {
-    final String cmdLine = validBaseCommandOptions();
-
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).as("CLI Parse result").isTrue();
     final Optional<ClientTlsOptions> optionalDownstreamTlsOptions = config.getClientTlsOptions();
@@ -131,7 +129,7 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void missingClientCertificateFileDisplaysErrorIfPasswordIsStillIncluded() {
-    String cmdLine = validBaseCommandOptions();
+    List<String> cmdLine = validBaseCommandOptions();
     parseCommandLineWithMissingParamsShowsError(
         parser,
         commandOutput,
@@ -143,7 +141,7 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void missingClientCertificatePasswordFileDisplaysErrorIfCertificateIsStillIncluded() {
-    String cmdLine = validBaseCommandOptions();
+    List<String> cmdLine = validBaseCommandOptions();
     parseCommandLineWithMissingParamsShowsError(
         parser,
         commandOutput,
@@ -155,14 +153,14 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void cmdLineIsValidWhenTlsClientCertificateOptionsAreMissing() {
-    final String cmdLine =
-        removeFieldFrom(
+    final List<String> cmdLine =
+        removeFieldsFrom(
             validBaseCommandOptions(),
             "downstream-http-tls-keystore-file",
             "downstream-http-tls-keystore-password-file");
 
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
     final ClientTlsOptions clientTlsOptions = config.getClientTlsOptions().get();
@@ -173,15 +171,14 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void cmdLineIsValidIfOnlyDownstreamKnownServerIsSpecified() {
-    final String cmdLine =
-        removeFieldFrom(
+    List<String> cmdLine =
+        removeFieldsFrom(
             validBaseCommandOptions(),
             "downstream-http-tls-keystore-file",
             "downstream-http-tls-keystore-password-file",
             "downstream-http-tls-ca-auth-enabled");
-
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
 
@@ -193,22 +190,23 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void downstreamKnownServerIsRequiredIfCaSignedDisableWithoutKnownServersFile() {
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add(subCommand.getCommandName());
     parseCommandLineWithMissingParamsShowsError(
         parser,
         commandOutput,
         commandError,
         subSignerDefaultUsageText,
-        validBaseCommandOptions() + subCommand.getCommandName(),
+        cmdLine,
         List.of("downstream-http-tls-known-servers-file"));
   }
 
   @Test
   void cmdLineIsValidWithCaAuthEnabledExplicitly() {
-    final String cmdLine =
+    List<String> cmdLine =
         modifyField(validBaseCommandOptions(), "downstream-http-tls-ca-auth-enabled", "true");
-
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).as("CLI Parse result").isTrue();
     final Optional<ClientTlsOptions> optionalDownstreamTlsOptions = config.getClientTlsOptions();
@@ -217,12 +215,11 @@ class CommandlineParserClientTlsOptionsTest {
 
   @Test
   void downstreamKnownServerIsNotRequiredIfCaSignedEnabledExplicitly() {
-    final String cmdLine0 =
+    List<String> cmdLine =
         modifyField(validBaseCommandOptions(), "downstream-http-tls-ca-auth-enabled", "true");
-    final String cmdLine = removeFieldFrom(cmdLine0, "downstream-http-tls-known-servers-file");
-
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine = removeFieldsFrom(cmdLine, "downstream-http-tls-known-servers-file");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).as("CLI Parse result").isTrue();
     final Optional<ClientTlsOptions> optionalDownstreamTlsOptions = config.getClientTlsOptions();

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -14,7 +14,7 @@ package tech.pegasys.ethsigner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.CmdlineHelpers.modifyField;
-import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldFrom;
+import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldsFrom;
 import static tech.pegasys.ethsigner.CmdlineHelpers.validBaseCommandOptions;
 import static tech.pegasys.ethsigner.CommandlineParser.MISSING_SUBCOMMAND_ERROR;
 import static tech.pegasys.ethsigner.util.CommandLineParserAssertions.parseCommandLineWithMissingParamsShowsError;
@@ -67,9 +67,9 @@ class CommandlineParserTest {
 
   @Test
   void fullyPopulatedCommandLineParsesIntoVariables() {
-    final boolean result =
-        parser.parseCommandLine(
-            (validBaseCommandOptions() + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result =parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
 
@@ -83,6 +83,7 @@ class CommandlineParserTest {
     assertThat(config.getDownstreamHttpRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
     assertThat(config.getHttpListenHost()).isEqualTo("localhost");
     assertThat(config.getHttpListenPort()).isEqualTo(5001);
+    assertThat(config.getCorsAllowedOrigins()).isEmpty();
     assertThat(config.getTlsOptions()).isNotEmpty();
     assertThat(config.getTlsOptions().get().getKeyStoreFile())
         .isEqualTo(new File("./keystore.pfx"));
@@ -91,6 +92,7 @@ class CommandlineParserTest {
     assertThat(tlsClientConstaints.getKnownClientsFile())
         .isEqualTo(Optional.of(new File("./known_clients")));
     assertThat(tlsClientConstaints.isCaAuthorizedClientAllowed()).isTrue();
+
 
     final Optional<ClientTlsOptions> downstreamTlsOptionsOptional = config.getClientTlsOptions();
     assertThat(downstreamTlsOptionsOptional.isPresent()).isTrue();
@@ -119,7 +121,7 @@ class CommandlineParserTest {
 
   @Test
   void missingSubCommandShowsErrorAndUsageText() {
-    final boolean result = parser.parseCommandLine(validBaseCommandOptions().split(" "));
+    final boolean result = parser.parseCommandLine(validBaseCommandOptions().toArray(String[]::new));
     assertThat(result).isFalse();
     assertThat(commandError.toString()).contains(MISSING_SUBCOMMAND_ERROR);
     assertThat(commandOutput.toString()).contains(defaultUsageText);
@@ -127,8 +129,8 @@ class CommandlineParserTest {
 
   @Test
   void nonIntegerInputForDownstreamPortShowsError() {
-    final String args = modifyField(validBaseCommandOptions(), "downstream-http-port", "abc");
-    final boolean result = parser.parseCommandLine(args.split(" "));
+    final List<String> args = modifyField(validBaseCommandOptions(), "downstream-http-port", "abc");
+    final boolean result = parser.parseCommandLine(args.toArray(String[]::new));
     assertThat(result).isFalse();
     assertThat(commandError.toString()).contains("--downstream-http-port", "'abc' is not an int");
     assertThat(commandOutput.toString()).containsOnlyOnce(defaultUsageText);
@@ -211,10 +213,10 @@ class CommandlineParserTest {
   private <T> void missingOptionalParameterIsValidAndMeetsDefault(
       final String paramToRemove, final Supplier<T> actualValueGetter, final T expectedValue) {
 
-    String cmdLine = removeFieldFrom(validBaseCommandOptions(), paramToRemove);
-    cmdLine += subCommand.getCommandName();
+    List<String> cmdLine = removeFieldsFrom(validBaseCommandOptions(), paramToRemove);
+    cmdLine.add(subCommand.getCommandName());
 
-    final boolean result = parser.parseCommandLine(cmdLine.split(" "));
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
     assertThat(result).isTrue();
     assertThat(actualValueGetter.get()).isEqualTo(expectedValue);
     assertThat(commandOutput.toString()).isEmpty();
@@ -227,9 +229,9 @@ class CommandlineParserTest {
     parser = new CommandlineParser(config, outputWriter, errorWriter);
     parser.registerSigner(subCommand);
 
-    final boolean result =
-        parser.parseCommandLine(
-            (validBaseCommandOptions() + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isFalse();
     assertThat(commandError.toString())
@@ -243,22 +245,20 @@ class CommandlineParserTest {
 
   @Test
   void settingTlsKnownClientAndDisablingClientAuthenticationShowsError() {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine += "--tls-allow-any-client ";
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
-
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add("--tls-allow-any-client");
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
     assertThat(result).isFalse();
     assertThat(commandError.toString()).contains("expected only one match but got");
   }
 
   @Test
   void tlsClientAuthenticationCanBeDisabledByRemovingKnownClientsAndSettingOption() {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine = removeFieldFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
-    cmdLine += "--tls-allow-any-client ";
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldsFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
+    cmdLine.add("--tls-allow-any-client");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
     assertThat(config.getTlsOptions().get().getClientAuthConstraints()).isEmpty();
@@ -266,21 +266,21 @@ class CommandlineParserTest {
 
   @Test
   void notExplicitlySettingTlsClientAuthFailsParsing() {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine = removeFieldFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldsFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isFalse();
   }
 
   @Test
   void parsingShouldFailIfTlsDisableClientAuthenticationHasAValue() {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine = removeFieldFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
-    cmdLine += "--tls-allow-any-client=false ";
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldsFrom(cmdLine, "tls-known-clients-file", "tls-allow-ca-clients");
+    cmdLine.add("--tls-allow-any-client=false");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isFalse();
     assertThat(commandError.toString()).contains("--tls-allow-any-client");
@@ -330,16 +330,14 @@ class CommandlineParserTest {
 
   @Test
   void ethSignerStartsValidlyIfNoTlsOptionsAreSet() {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine =
-        removeFieldFrom(
-            cmdLine,
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldsFrom(cmdLine,
             "tls-keystore-file",
             "tls-keystore-password-file",
             "tls-known-clients-file",
             "tls-allow-ca-clients");
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
     assertThat(config.getTlsOptions()).isEmpty();
@@ -348,11 +346,21 @@ class CommandlineParserTest {
   @ParameterizedTest
   @ValueSource(strings = {"=", " ", "&", "?", "#"})
   void illegalDownStreamPathThrowsException(final String illegalChar) {
-    String cmdLine = validBaseCommandOptions();
-    cmdLine = removeFieldFrom(cmdLine, "downstream-http-path");
-    cmdLine += " --downstream-http-path=path1/" + illegalChar + "path2";
-    final boolean result =
-        parser.parseCommandLine((cmdLine + subCommand.getCommandName()).split(" "));
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine = removeFieldsFrom(cmdLine, "downstream-http-path");
+    cmdLine.add("--downstream-http-path=path1/" + illegalChar + "path2 ");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
     assertThat(result).isFalse();
+  }
+
+  @Test
+  void configContainsCorsValueSetOnCmdline() {
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add("--http-cors-origins=sample.com");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
+    assertThat(result).isTrue();
+    assertThat(config.getCorsAllowedOrigins()).containsOnly("sample.com");
   }
 }

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -363,4 +363,14 @@ class CommandlineParserTest {
     assertThat(result).isTrue();
     assertThat(config.getCorsAllowedOrigins()).containsOnly("sample.com");
   }
+
+  @Test
+  void corsCanBeACommaSeparatedList() {
+    List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add("--http-cors-origins=sample.com,mydomain.com");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
+    assertThat(result).isTrue();
+    assertThat(config.getCorsAllowedOrigins()).contains("sample.com", "mydomain.com");
+  }
 }

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -67,7 +67,7 @@ class CommandlineParserTest {
 
   @Test
   void fullyPopulatedCommandLineParsesIntoVariables() {
-    List<String> cmdLine = validBaseCommandOptions();
+    final List<String> cmdLine = validBaseCommandOptions();
     cmdLine.add(subCommand.getCommandName());
     final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
@@ -358,7 +358,7 @@ class CommandlineParserTest {
 
   @Test
   void configContainsCorsValueSetOnCmdline() {
-    List<String> cmdLine = validBaseCommandOptions();
+    final List<String> cmdLine = validBaseCommandOptions();
     cmdLine.add("--http-cors-origins=sample.com");
     cmdLine.add(subCommand.getCommandName());
     final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
@@ -368,11 +368,21 @@ class CommandlineParserTest {
 
   @Test
   void corsCanBeACommaSeparatedList() {
-    List<String> cmdLine = validBaseCommandOptions();
+    final List<String> cmdLine = validBaseCommandOptions();
     cmdLine.add("--http-cors-origins=sample.com,mydomain.com");
     cmdLine.add(subCommand.getCommandName());
     final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
     assertThat(result).isTrue();
     assertThat(config.getCorsAllowedOrigins()).contains("sample.com", "mydomain.com");
+  }
+
+  @Test
+  void corsValueOfNoneLiteralProducesEmptyListInConfig() {
+    final List<String> cmdLine = validBaseCommandOptions();
+    cmdLine.add("--http-cors-origins=none");
+    cmdLine.add(subCommand.getCommandName());
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
+    assertThat(result).isTrue();
+    assertThat(config.getCorsAllowedOrigins()).isEmpty();
   }
 }

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/CommandlineParserTest.java
@@ -69,7 +69,7 @@ class CommandlineParserTest {
   void fullyPopulatedCommandLineParsesIntoVariables() {
     List<String> cmdLine = validBaseCommandOptions();
     cmdLine.add(subCommand.getCommandName());
-    final boolean result =parser.parseCommandLine(cmdLine.toArray(String[]::new));
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
 
     assertThat(result).isTrue();
 
@@ -92,7 +92,6 @@ class CommandlineParserTest {
     assertThat(tlsClientConstaints.getKnownClientsFile())
         .isEqualTo(Optional.of(new File("./known_clients")));
     assertThat(tlsClientConstaints.isCaAuthorizedClientAllowed()).isTrue();
-
 
     final Optional<ClientTlsOptions> downstreamTlsOptionsOptional = config.getClientTlsOptions();
     assertThat(downstreamTlsOptionsOptional.isPresent()).isTrue();
@@ -121,7 +120,8 @@ class CommandlineParserTest {
 
   @Test
   void missingSubCommandShowsErrorAndUsageText() {
-    final boolean result = parser.parseCommandLine(validBaseCommandOptions().toArray(String[]::new));
+    final boolean result =
+        parser.parseCommandLine(validBaseCommandOptions().toArray(String[]::new));
     assertThat(result).isFalse();
     assertThat(commandError.toString()).contains(MISSING_SUBCOMMAND_ERROR);
     assertThat(commandOutput.toString()).contains(defaultUsageText);
@@ -331,7 +331,9 @@ class CommandlineParserTest {
   @Test
   void ethSignerStartsValidlyIfNoTlsOptionsAreSet() {
     List<String> cmdLine = validBaseCommandOptions();
-    cmdLine = removeFieldsFrom(cmdLine,
+    cmdLine =
+        removeFieldsFrom(
+            cmdLine,
             "tls-keystore-file",
             "tls-keystore-password-file",
             "tls-known-clients-file",

--- a/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/util/CommandLineParserAssertions.java
+++ b/ethsigner/commandline/src/test/java/tech/pegasys/ethsigner/util/CommandLineParserAssertions.java
@@ -13,7 +13,7 @@
 package tech.pegasys.ethsigner.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldFrom;
+import static tech.pegasys.ethsigner.CmdlineHelpers.removeFieldsFrom;
 
 import tech.pegasys.ethsigner.CommandlineParser;
 
@@ -28,11 +28,11 @@ public final class CommandLineParserAssertions {
       final Writer outputWriter,
       final Writer errorWriter,
       final String defaultUsageText,
-      final String inputCmdLine,
+      final List<String> inputCmdLine,
       final List<String> paramsToRemove) {
-    final String cmdLine =
-        removeFieldFrom(inputCmdLine, paramsToRemove.stream().toArray(String[]::new));
-    final boolean result = parser.parseCommandLine(cmdLine.split(" "));
+    final List<String> cmdLine =
+        removeFieldsFrom(inputCmdLine, paramsToRemove.stream().toArray(String[]::new));
+    final boolean result = parser.parseCommandLine(cmdLine.toArray(String[]::new));
     assertThat(result).as("Parse Results After Removing Params").isFalse();
 
     final String output = errorWriter.toString();

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -147,7 +147,7 @@ public class IntegrationTestBase {
             jsonDecoder,
             dataPath,
             vertx,
-            singletonList("*"));
+            singletonList("sample.com"));
     runner.start();
 
     final Path portsFile = dataPath.resolve(PORTS_FILENAME);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/IntegrationTestBase.java
@@ -15,6 +15,7 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 import static io.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
@@ -145,7 +146,8 @@ public class IntegrationTestBase {
             new DownstreamPathCalculator(downstreamHttpRequestPath),
             jsonDecoder,
             dataPath,
-            vertx);
+            vertx,
+            singletonList("*"));
     runner.start();
 
     final Path portsFile = dataPath.resolve(PORTS_FILENAME);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -14,11 +14,12 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static java.util.Collections.singletonMap;
 
-import java.io.IOException;
-import java.util.Map;
-
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.json.Json;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.CipherException;
@@ -172,5 +173,26 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
         "/login");
 
     verifyEthNodeReceived(REQUEST_HEADERS, LOGIN_BODY, ROOT_PATH + "/login");
+  }
+
+  @Test
+  void requestWithOriginHeaderProducesResponseWithCorsHeader() {
+    final String netVersionRequest = Json.encode(jsonRpc().netVersion());
+    final Response<String> netVersion = new NetVersion();
+    netVersion.setResult("4");
+    final String netVersionResponse = Json.encode(netVersion);
+
+    final String originDomain = "sample.com";
+
+    setUpEthNodeResponse(
+        request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
+
+    final Map<String, String> expectedResponseHeaders = new HashMap<>(RESPONSE_HEADERS);
+    expectedResponseHeaders.put(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*");
+
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(Map.of("Accept", "*/*", "Host", "localhost", "Origin", originDomain), netVersionRequest),
+        response.ethSigner(expectedResponseHeaders, netVersionResponse));
+
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -197,4 +197,18 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
             netVersionRequest),
         response.ethSigner(expectedResponseHeaders, netVersionResponse));
   }
+
+  @Test
+  void requestWithMisMatchedDomainReceives403() {
+    final String netVersionRequest = Json.encode(jsonRpc().netVersion());
+    final Response<String> netVersion = new NetVersion();
+    netVersion.setResult("4");
+    final String originDomain = "notSample.com";
+
+    sendPostRequestAndVerifyResponse(
+        request.ethSigner(
+            Map.of("Accept", "*/*", "Host", "localhost", "Origin", originDomain),
+            netVersionRequest),
+        response.ethSigner("", HttpResponseStatus.FORBIDDEN));
+  }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -189,7 +189,7 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
 
     final Map<String, String> expectedResponseHeaders = new HashMap<>(RESPONSE_HEADERS);
-    expectedResponseHeaders.put(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*");
+    expectedResponseHeaders.put(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "sample.com");
 
     sendPostRequestAndVerifyResponse(
         request.ethSigner(

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -193,6 +193,5 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
     sendPostRequestAndVerifyResponse(
         request.ethSigner(Map.of("Accept", "*/*", "Host", "localhost", "Origin", originDomain), netVersionRequest),
         response.ethSigner(expectedResponseHeaders, netVersionResponse));
-
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -14,12 +14,13 @@ package tech.pegasys.ethsigner.jsonrpcproxy;
 
 import static java.util.Collections.singletonMap;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.json.Json;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.Json;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.web3j.crypto.CipherException;
@@ -191,7 +192,9 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
     expectedResponseHeaders.put(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*");
 
     sendPostRequestAndVerifyResponse(
-        request.ethSigner(Map.of("Accept", "*/*", "Host", "localhost", "Origin", originDomain), netVersionRequest),
+        request.ethSigner(
+            Map.of("Accept", "*/*", "Host", "localhost", "Origin", originDomain),
+            netVersionRequest),
         response.ethSigner(expectedResponseHeaders, netVersionResponse));
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/ProxyIntegrationTest.java
@@ -189,7 +189,8 @@ public class ProxyIntegrationTest extends IntegrationTestBase {
         request.ethNode(netVersionRequest), response.ethNode(RESPONSE_HEADERS, netVersionResponse));
 
     final Map<String, String> expectedResponseHeaders = new HashMap<>(RESPONSE_HEADERS);
-    expectedResponseHeaders.put(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "sample.com");
+    expectedResponseHeaders.put(
+        HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "sample.com");
 
     sendPostRequestAndVerifyResponse(
         request.ethSigner(

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
@@ -515,7 +515,7 @@ class SigningEthSendTransactionIntegrationTest extends DefaultTestBase {
   }
 
   @Test
-  void ensureTranactionRespsonseContainsCorsHeader() {
+  void ensureTranactionResponseContainsCorsHeader() {
     final Request<?, EthSendTransaction> sendTransactionRequest =
         sendTransaction.request(Transaction.smartContract());
     final String sendRawTransactionRequest = sendRawTransaction.request(sendTransactionRequest);

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
@@ -25,22 +25,21 @@ import static tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendTransaction.
 import static tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendTransaction.FIELD_VALUE_DEFAULT;
 import static tech.pegasys.ethsigner.jsonrpcproxy.support.TransactionCountResponder.TRANSACTION_COUNT_METHOD.ETH_GET_TRANSACTION_COUNT;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.vertx.core.json.Json;
-import java.util.Map;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendRawTransaction;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.SendTransaction;
 import tech.pegasys.ethsigner.jsonrpcproxy.model.jsonrpc.Transaction;
 import tech.pegasys.ethsigner.jsonrpcproxy.support.TransactionCountResponder;
 
+import java.util.Map;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.core.json.Json;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 
-/**
- * Signing is a step during proxying a sendTransaction() JSON-RPC request to an Ethereum node.
- */
+/** Signing is a step during proxying a sendTransaction() JSON-RPC request to an Ethereum node. */
 class SigningEthSendTransactionIntegrationTest extends DefaultTestBase {
 
   private SendTransaction sendTransaction;
@@ -530,7 +529,8 @@ class SigningEthSendTransactionIntegrationTest extends DefaultTestBase {
 
     sendPostRequestAndVerifyResponse(
         request.ethSigner(Map.of("Origin", originDomain), Json.encode(sendTransactionRequest)),
-        response.ethSigner(Map.of(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*"),
+        response.ethSigner(
+            Map.of(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*"),
             sendRawTransactionResponse));
   }
 }

--- a/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
+++ b/ethsigner/core/src/integration-test/java/tech/pegasys/ethsigner/jsonrpcproxy/SigningEthSendTransactionIntegrationTest.java
@@ -530,7 +530,7 @@ class SigningEthSendTransactionIntegrationTest extends DefaultTestBase {
     sendPostRequestAndVerifyResponse(
         request.ethSigner(Map.of("Origin", originDomain), Json.encode(sendTransactionRequest)),
         response.ethSigner(
-            Map.of(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*"),
+            Map.of(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "sample.com"),
             sendRawTransactionResponse));
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/CorsAllowedOriginsProperty.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/CorsAllowedOriginsProperty.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import javax.annotation.Nonnull;
+
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+
+public class CorsAllowedOriginsProperty extends AbstractList<String> {
+
+  private final List<String> domains = new ArrayList<>();
+
+  public CorsAllowedOriginsProperty() {}
+
+  @Override
+  @Nonnull
+  public Iterator<String> iterator() {
+    if (domains.size() == 1 && domains.get(0).equals("none")) {
+      return Collections.emptyIterator();
+    } else {
+      return domains.iterator();
+    }
+  }
+
+  @Override
+  public int size() {
+    return domains.size();
+  }
+
+  @Override
+  public boolean add(final String string) {
+    return addAll(Collections.singleton(string));
+  }
+
+  @Override
+  public String get(final int index) {
+    return domains.get(index);
+  }
+
+  @Override
+  public boolean addAll(final Collection<? extends String> collection) {
+    final int initialSize = domains.size();
+    for (final String string : collection) {
+      if (Strings.isNullOrEmpty(string)) {
+        throw new IllegalArgumentException("Domain cannot be empty string or null string.");
+      }
+      for (final String s : Splitter.onPattern("\\s*,+\\s*").split(string)) {
+        if ("all".equals(s)) {
+          domains.add("*");
+        } else {
+          domains.add(s);
+        }
+      }
+    }
+
+    if (domains.contains("none")) {
+      if (domains.size() > 1) {
+        throw new IllegalArgumentException("Value 'none' can't be used with other domains");
+      }
+    } else if (domains.contains("*")) {
+      if (domains.size() > 1) {
+        throw new IllegalArgumentException("Values '*' or 'all' can't be used with other domains");
+      }
+    } else {
+      try {
+        final StringJoiner stringJoiner = new StringJoiner("|");
+        domains.forEach(stringJoiner::add);
+        Pattern.compile(stringJoiner.toString());
+      } catch (final PatternSyntaxException e) {
+        throw new IllegalArgumentException("Domain values result in invalid regex pattern", e);
+      }
+    }
+
+    return domains.size() != initialSize;
+  }
+}

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -83,7 +83,8 @@ public final class EthSigner {
               new DownstreamPathCalculator(config.getDownstreamHttpPath()),
               jsonDecoder,
               config.getDataPath(),
-              vertx);
+              vertx,
+              config.getCorsAllowedOrigins());
 
       runner.start();
     } catch (final Throwable t) {

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.ethsigner.core;
 
+import com.google.common.collect.Sets;
 import tech.pegasys.ethsigner.core.http.HttpResponseFactory;
 import tech.pegasys.ethsigner.core.http.HttpServerService;
 import tech.pegasys.ethsigner.core.http.JsonRpcErrorHandler;
@@ -113,8 +114,8 @@ public class Runner {
         .route()
         .handler(
             CorsHandler.create(buildCorsRegexFromConfig())
-                .allowedHeader("*")
-                .allowedHeader("content-type"));
+                .allowedHeaders(Sets.newHashSet("*", "content-type"))
+                .allowedMethods(Sets.newHashSet(HttpMethod.POST, HttpMethod.GET)));
     router
         .route(HttpMethod.POST, "/")
         .produces(JSON)

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.ethsigner.core;
 
-import com.google.common.collect.Sets;
 import tech.pegasys.ethsigner.core.http.HttpResponseFactory;
 import tech.pegasys.ethsigner.core.http.HttpServerService;
 import tech.pegasys.ethsigner.core.http.JsonRpcErrorHandler;
@@ -41,6 +40,7 @@ import java.util.Collection;
 import java.util.Properties;
 import java.util.StringJoiner;
 
+import com.google.common.collect.Sets;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -114,8 +114,7 @@ public class Runner {
         .route()
         .handler(
             CorsHandler.create(buildCorsRegexFromConfig())
-                .allowedHeaders(Sets.newHashSet("*", "content-type"))
-                .allowedMethods(Sets.newHashSet(HttpMethod.POST, HttpMethod.GET)));
+                .allowedHeaders(Sets.newHashSet("*", "content-type")));
     router
         .route(HttpMethod.POST, "/")
         .produces(JSON)

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -36,7 +36,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Properties;
+import java.util.StringJoiner;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.AsyncResult;
@@ -47,6 +49,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.handler.ResponseContentTypeHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,6 +70,7 @@ public class Runner {
   private final Path dataPath;
   private final Vertx vertx;
   private final HttpServerService httpServerService;
+  private final Collection<String> allowedCorsOrigins;
 
   public Runner(
       final long chainId,
@@ -77,7 +81,8 @@ public class Runner {
       final DownstreamPathCalculator downstreamPathCalculator,
       final JsonDecoder jsonDecoder,
       final Path dataPath,
-      final Vertx vertx) {
+      final Vertx vertx,
+      final Collection<String> allowedCorsOrigins) {
     this.chainId = chainId;
     this.transactionSignerProvider = transactionSignerProvider;
     this.clientOptions = clientOptions;
@@ -86,6 +91,7 @@ public class Runner {
     this.jsonDecoder = jsonDecoder;
     this.dataPath = dataPath;
     this.vertx = vertx;
+    this.allowedCorsOrigins = allowedCorsOrigins;
     this.httpServerService = new HttpServerService(router(), serverOptions);
   }
 
@@ -103,6 +109,12 @@ public class Runner {
     final Router router = Router.router(vertx);
 
     // Handler for JSON-RPC requests
+    router
+        .route()
+        .handler(
+            CorsHandler.create(buildCorsRegexFromConfig())
+                .allowedHeader("*")
+                .allowedHeader("content-type"));
     router
         .route(HttpMethod.POST, "/")
         .produces(JSON)
@@ -200,6 +212,19 @@ public class Runner {
           "This file contains the ports used by the running instance of Web3Provider. This file will be deleted after the node is shutdown.");
     } catch (final Exception e) {
       LOG.warn("Error writing ports file", e);
+    }
+  }
+
+  private String buildCorsRegexFromConfig() {
+    if (allowedCorsOrigins.isEmpty()) {
+      return "";
+    }
+    if (allowedCorsOrigins.contains("*")) {
+      return "*";
+    } else {
+      final StringJoiner stringJoiner = new StringJoiner("|");
+      allowedCorsOrigins.stream().filter(s -> !s.isEmpty()).forEach(stringJoiner::add);
+      return stringJoiner.toString();
     }
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -17,6 +17,7 @@ import tech.pegasys.ethsigner.core.signing.ChainIdProvider;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Optional;
 
 import org.apache.logging.log4j.Level;
@@ -44,4 +45,6 @@ public interface Config {
   Optional<TlsOptions> getTlsOptions();
 
   Optional<ClientTlsOptions> getClientTlsOptions();
+
+  Collection<String> getCorsAllowedOrigins();
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/passthrough/PassThroughHandler.java
@@ -69,7 +69,7 @@ public class PassThroughHandler implements JsonRpcRequestHandler, Handler<Routin
   private void handleResponseBody(
       final RoutingContext context, final HttpClientResponse response, final Buffer body) {
     context.request().response().setStatusCode(response.statusCode());
-    context.request().response().headers().setAll(response.headers());
+    context.request().response().headers().addAll(response.headers());
     context.request().response().setChunked(false);
     context.request().response().end(body);
   }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/TransactionTransmitter.java
@@ -144,7 +144,7 @@ public class TransactionTransmitter {
       final RoutingContext context, final HttpClientResponse response, final Buffer body) {
     final HttpServerRequest httpServerRequest = context.request();
     httpServerRequest.response().setStatusCode(response.statusCode());
-    httpServerRequest.response().headers().setAll(response.headers());
+    httpServerRequest.response().headers().addAll(response.headers());
     httpServerRequest.response().setChunked(false);
     httpServerRequest.response().end(body);
   }

--- a/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
+++ b/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
@@ -15,6 +15,9 @@ package tech.pegasys.ethsigner.subcommands;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.CmdlineHelpers.modifyField;
 
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.StringJoiner;
 import tech.pegasys.ethsigner.CmdlineHelpers;
 
 import java.io.ByteArrayOutputStream;
@@ -44,46 +47,35 @@ public class HashicorpSubCommandTest {
     hashicorpSubCommand = new HashicorpSubCommand();
   }
 
-  private boolean parseCommand(final String cmdLine) {
+  private boolean parseCommand(final List<String> cmdLine) {
     final CommandLine commandLine = new CommandLine(hashicorpSubCommand);
     commandLine.setCaseInsensitiveEnumValuesAllowed(true);
     commandLine.registerConverter(Level.class, Level::valueOf);
 
     try {
-      commandLine.parseArgs(cmdLine.split(" "));
+      commandLine.parseArgs(cmdLine.toArray(String[]::new));
     } catch (final CommandLine.ParameterException e) {
       return false;
     }
     return true;
   }
 
-  private String validCommandLine() {
-    return "--auth-file="
-        + THIS_IS_THE_PATH_TO_THE_FILE
-        + " --host="
-        + HTTP_HOST_COM
-        + " --port="
-        + PORT
-        + " --signing-key-path="
-        + PATH_TO_SIGNING_KEY
-        + " --timeout="
-        + FIFTEEN
-        + " --tls-known-server-file="
-        + TLS_KNOWN_SERVER_FILE;
+  private List<String> validCommandLine() {
+    return Lists.newArrayList("--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
+        " --host=" + HTTP_HOST_COM,
+        " --port=" + PORT,
+        " --signing-key-path=" + PATH_TO_SIGNING_KEY,
+        " --timeout=" + FIFTEEN,
+        " --tls-known-server-file=" + TLS_KNOWN_SERVER_FILE);
   }
 
-  private String validWithTlsDisabledCommandLine() {
-    return "--auth-file="
-        + THIS_IS_THE_PATH_TO_THE_FILE
-        + " --host="
-        + HTTP_HOST_COM
-        + " --port="
-        + PORT
-        + " --signing-key-path="
-        + PATH_TO_SIGNING_KEY
-        + " --timeout="
-        + FIFTEEN
-        + " --tls-enabled=false";
+  private List<String> validWithTlsDisabledCommandLine() {
+    return Lists.newArrayList("--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
+        " --host=" + HTTP_HOST_COM,
+        " --port=" + PORT,
+        " --signing-key-path=" + PATH_TO_SIGNING_KEY,
+        " --timeout=" + FIFTEEN,
+        " --tls-enabled=false");
   }
 
   @Test
@@ -122,14 +114,14 @@ public class HashicorpSubCommandTest {
 
   @Test
   public void nonIntegerInputForPortShowsError() {
-    final String cmdLine = modifyField(validCommandLine(), "port", "noInteger");
+    final List<String> cmdLine = modifyField(validCommandLine(), "port", "noInteger");
     final boolean result = parseCommand(cmdLine);
     assertThat(result).isFalse();
   }
 
   @Test
   public void nonIntegerInputForTimeoutShowsError() {
-    final String cmdLine = modifyField(validCommandLine(), "timeout", "noInteger");
+    final List<String> cmdLine = modifyField(validCommandLine(), "timeout", "noInteger");
     final boolean result = parseCommand(cmdLine);
     assertThat(result).isFalse();
   }
@@ -156,8 +148,8 @@ public class HashicorpSubCommandTest {
 
   @Test
   void cmdlineIsValidIftlsKnownServerFileIsMissing() {
-    final String cmdLine =
-        CmdlineHelpers.removeFieldFrom(validCommandLine(), "tls-known-server-file");
+    final List<String> cmdLine =
+        CmdlineHelpers.removeFieldsFrom(validCommandLine(), "tls-known-server-file");
     final boolean result = parseCommand(cmdLine);
 
     assertThat(result).isTrue();
@@ -165,7 +157,7 @@ public class HashicorpSubCommandTest {
   }
 
   private void missingParameterShowsError(final String paramToRemove) {
-    final String cmdLine = CmdlineHelpers.removeFieldFrom(validCommandLine(), paramToRemove);
+    final List<String> cmdLine = CmdlineHelpers.removeFieldsFrom(validCommandLine(), paramToRemove);
     final boolean result = parseCommand(cmdLine);
     assertThat(result).isFalse();
   }
@@ -174,7 +166,7 @@ public class HashicorpSubCommandTest {
       final String paramToRemove,
       final Supplier<String> actualValueGetter,
       final String expectedValue) {
-    final String cmdLine = CmdlineHelpers.removeFieldFrom(validCommandLine(), paramToRemove);
+    final List<String> cmdLine = CmdlineHelpers.removeFieldsFrom(validCommandLine(), paramToRemove);
     final boolean result = parseCommand(cmdLine);
     assertThat(result).isTrue();
     assertThat(actualValueGetter.get()).contains(expectedValue);

--- a/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
+++ b/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
@@ -15,15 +15,14 @@ package tech.pegasys.ethsigner.subcommands;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.ethsigner.CmdlineHelpers.modifyField;
 
-import com.google.common.collect.Lists;
-import java.util.List;
-import java.util.StringJoiner;
 import tech.pegasys.ethsigner.CmdlineHelpers;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.function.Supplier;
 
+import com.google.common.collect.Lists;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,21 +60,23 @@ public class HashicorpSubCommandTest {
   }
 
   private List<String> validCommandLine() {
-    return Lists.newArrayList("--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
-        " --host=" + HTTP_HOST_COM,
-        " --port=" + PORT,
-        " --signing-key-path=" + PATH_TO_SIGNING_KEY,
-        " --timeout=" + FIFTEEN,
-        " --tls-known-server-file=" + TLS_KNOWN_SERVER_FILE);
+    return Lists.newArrayList(
+        "--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
+        "--host=" + HTTP_HOST_COM,
+        "--port=" + PORT,
+        "--signing-key-path=" + PATH_TO_SIGNING_KEY,
+        "--timeout=" + FIFTEEN,
+        "--tls-known-server-file=" + TLS_KNOWN_SERVER_FILE);
   }
 
   private List<String> validWithTlsDisabledCommandLine() {
-    return Lists.newArrayList("--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
-        " --host=" + HTTP_HOST_COM,
-        " --port=" + PORT,
-        " --signing-key-path=" + PATH_TO_SIGNING_KEY,
-        " --timeout=" + FIFTEEN,
-        " --tls-enabled=false");
+    return Lists.newArrayList(
+        "--auth-file=" + THIS_IS_THE_PATH_TO_THE_FILE,
+        "--host=" + HTTP_HOST_COM,
+        "--port=" + PORT,
+        "--signing-key-path=" + PATH_TO_SIGNING_KEY,
+        "--timeout=" + FIFTEEN,
+        "--tls-enabled=false");
   }
 
   @Test


### PR DESCRIPTION
Ethsigner will handle all cors requests, regardless of the
json rpc method that is being targetted.

Ideally, all other cors requests would be forwarded to besu for
handling, however that is a problem for later.

This resolves Ethsigner issue #278.