### PR TITLE
Update references of using Jira to use Github for issue tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,12 @@ open a new issue and include a link to the original issue in the body of your ne
 #### Before Submitting A Bug Report
 * **Confirm the problem** is reproducible in the latest version of the software.
 * **Check [EthSigner documentation]**. You might be able to find the cause of the problem and fix things yourself. 
-* **Perform a cursory search of project issues in [Jira]** 
+* **Perform a cursory search of project issues in [Github issues]** 
 to see if the problem has already been reported. If it has **and the issue is still open**, add a comment 
 to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?
-Bugs are tracked as issues in [Jira].  
+Bugs are tracked as issues in [Github issues].  
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -111,13 +111,13 @@ When you are creating an enhancement suggestion, please
 #### Before Submitting An Enhancement Suggestion
 
 * **Check the [EthSigner documentation].** You might be able to find the cause of the problem and fix things yourself. 
-* **Perform a cursory search of project issues in [Jira]** 
+* **Perform a cursory search of project issues in [Github issues]** 
 to see if the problem has already been reported. If it has **and the issue is still open**, add a comment 
 to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
-Enhancement suggestions are tracked as issues in [Jira].
+Enhancement suggestions are tracked as issues in [Github issues].
 Provide the following information:
 
 * **Use a clear and descriptive title** for the issue to identify the suggestion.
@@ -133,7 +133,7 @@ Provide the following information:
 * **Specify the name and version of the OS you're using.**
 
 ## Your First Contribution
-Start by looking through the 'good first issue' and 'help wanted' labeled issues on the [Jira] dashboard:
+Start by looking through the 'good first issue' and 'help wanted' labeled issues in [Github issues]:
 * [Good First Issue][search-label-good-first-issue] - issues which should only require a few lines of code or documentation, 
 and a test or two.
 * [Help wanted issues][search-label-help-wanted] - issues which are a bit more involved than `good first issue` issues.
@@ -161,11 +161,11 @@ For this reason do not mix any formatting fixes or code moves with actual code c
 another part of the software. Running the `./gradlew clean check test` command locally will help you
 to be confident that your changes will pass CI tests once pushed as a Pull Request.
 1. **Push your changes** to your remote fork (usually labeled as `origin`).
-1. **Create a pull-request** (PR) on the EthSigner repository. If the PR addresses an existing Jira issue, 
+1. **Create a pull-request** (PR) on the EthSigner repository. If the PR addresses an existing GitHub issue, 
 include the issue number in the PR title in square brackets (for example, `[ES-2374]`). 
 1. **Add labels** to identify the type of your PR. _For example, if your PR is not ready to validate,
 add the "work-in-progress" label. If it fixes a bug, add the "bug" label._
-1. If the PR address an existing Jira issue, comment in the Jira issue with the PR number. 
+1. If the PR address an existing GitHub issue, comment in the GitHub issue with the PR number. 
 1. **Ensure your changes are reviewed**.
 _Select the reviewers you would like to review your PR.
 If you don't know who to choose, simply select the reviewers proposed by GitHub or leave blank._
@@ -244,7 +244,7 @@ These are not strictly enforced during the build, but should be adhered to and c
 
 [private@pegasys.tech]: mailto:private@pegasys.tech
 [Gitter]: https://gitter.im/PegaSysEng/EthSigner
-[Jira]: https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10121
+[Github issues]: https://github.com/PegaSysEng/ethsigner/issues
 [EthSigner documentation]: https://docs.ethsigner.pegasys.tech/
 [CLA.md]: /CLA.md
 [Code Reviews]: /community/code-reviews.md

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A transaction signing application to be used with a web3 provider. All questions
 
 ## Issues
 
-Eth2Signer issues are tracked in [GitHub issues].
+EthSigner issues are tracked in [GitHub issues].
 
 See our [contribution guidelines](CONTRIBUTING.md) for more detail on searching and creating issues.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A transaction signing application to be used with a web3 provider. All questions
 
 ## Issues
 
-EthSigner issues are tracked in [Jira] not GitHub.
+Eth2Signer issues are tracked in [GitHub issues].
 
 See our [contribution guidelines](CONTRIBUTING.md) for more detail on searching and creating issues.
 
@@ -19,4 +19,4 @@ See our [contribution guidelines](CONTRIBUTING.md) for more detail on searching 
 * [Release Notes](CHANGELOG.md)
 
 [Gitter]: https://gitter.im/PegaSysEng/EthSigner
-[Jira]: https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10121
+[Github issues]: https://github.com/PegaSysEng/ethsigner/issues


### PR DESCRIPTION
Jira is no longer being used for issue tracking we are now using Github. This updates the documentation to reflect this.