### PR TITLE
Upgrade docker-java version 3.2.5

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.github.docker-java:docker-java:3.2.0'
+    dependency 'com.github.docker-java:docker-java:3.2.5'
 
     dependency 'com.google.errorprone:error_prone_annotation:2.3.4'
     dependency 'com.google.errorprone:error_prone_check_api:2.3.4'


### PR DESCRIPTION
Fixes docker-java API issues to work with latest JDK release.

Signed-off-by: Usman Saleem <usman@usmans.info>