### PR TITLE
File name is checked in SendTransactionHandler

### DIFF
--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerRunner.java
@@ -101,7 +101,7 @@ public abstract class EthSignerRunner {
   }
 
   public void start(final String processName) {
-    final String loggingLevel = "TRACE";
+    final String loggingLevel = "DEBUG";
 
     final List<String> params = new ArrayList<>();
     params.add("--logging");

--- a/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerRunner.java
+++ b/acceptance-tests/src/test/java/tech/pegasys/ethsigner/tests/dsl/signer/EthSignerRunner.java
@@ -101,7 +101,7 @@ public abstract class EthSignerRunner {
   }
 
   public void start(final String processName) {
-    final String loggingLevel = "DEBUG";
+    final String loggingLevel = "TRACE";
 
     final List<String> params = new ArrayList<>();
     params.add("--logging");

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -85,9 +85,11 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
     }
 
     final HexStringComparator comparator = new HexStringComparator();
-    if(comparator.compare(transactionSigner.get().getAddress(), transaction.sender()) != 0) {
-      LOG.info("Ethereum address derived from identifier ({}) is incorrect value ({})",
-          transaction.sender(), transactionSigner.get().getAddress());
+    if (comparator.compare(transactionSigner.get().getAddress(), transaction.sender()) != 0) {
+      LOG.info(
+          "Ethereum address derived from identifier ({}) is incorrect value ({})",
+          transaction.sender(),
+          transactionSigner.get().getAddress());
       context.fail(INTERNAL_SERVER_ERROR.code(), new JsonRpcException(TX_SENDER_NOT_AUTHORIZED));
       return;
     }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/SendTransactionHandler.java
@@ -13,8 +13,10 @@
 package tech.pegasys.ethsigner.core.requesthandler.sendtransaction;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.INVALID_PARAMS;
 import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT;
+import static tech.pegasys.ethsigner.core.jsonrpc.response.JsonRpcError.TX_SENDER_NOT_AUTHORIZED;
 
 import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequest;
 import tech.pegasys.ethsigner.core.jsonrpc.exception.JsonRpcException;
@@ -23,6 +25,7 @@ import tech.pegasys.ethsigner.core.requesthandler.VertxRequestTransmitterFactory
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.Transaction;
 import tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction.TransactionFactory;
 import tech.pegasys.ethsigner.core.signing.TransactionSerializer;
+import tech.pegasys.ethsigner.core.util.HexStringComparator;
 import tech.pegasys.signers.secp256k1.api.TransactionSigner;
 import tech.pegasys.signers.secp256k1.api.TransactionSignerProvider;
 
@@ -78,6 +81,14 @@ public class SendTransactionHandler implements JsonRpcRequestHandler {
       LOG.info("From address ({}) does not match any available account", transaction.sender());
       context.fail(
           BAD_REQUEST.code(), new JsonRpcException(SIGNING_FROM_IS_NOT_AN_UNLOCKED_ACCOUNT));
+      return;
+    }
+
+    final HexStringComparator comparator = new HexStringComparator();
+    if(comparator.compare(transactionSigner.get().getAddress(), transaction.sender()) != 0) {
+      LOG.info("Ethereum address derived from identifier ({}) is incorrect value ({})",
+          transaction.sender(), transactionSigner.get().getAddress());
+      context.fail(INTERNAL_SERVER_ERROR.code(), new JsonRpcException(TX_SENDER_NOT_AUTHORIZED));
       return;
     }
 

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
@@ -9,12 +9,11 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 package tech.pegasys.ethsigner.core.util;
 
 import java.util.Comparator;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class HexStringComparator implements Comparator<String> {

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
@@ -19,7 +19,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class HexStringComparator implements Comparator<String> {
 
   @Override
-  public int compare(String l, String r) {
+  public int compare(final String l, final String r) {
     final Bytes leftBytes = Bytes.fromHexString(l);
     final Bytes rightBytes = Bytes.fromHexString(r);
     return leftBytes.compareTo(rightBytes);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/util/HexStringComparator.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.ethsigner.core.util;
+
+import java.util.Comparator;
+import org.apache.tuweni.bytes.Bytes;
+
+public class HexStringComparator implements Comparator<String> {
+
+  @Override
+  public int compare(String l, String r) {
+    final Bytes leftBytes = Bytes.fromHexString(l);
+    final Bytes rightBytes = Bytes.fromHexString(r);
+    return leftBytes.compareTo(rightBytes);
+  }
+}

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/util/HexStringComparatorTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/util/HexStringComparatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.ethsigner.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HexStringComparatorTest {
+
+  final HexStringComparator comparator = new HexStringComparator();
+
+  @ParameterizedTest
+  @ValueSource(strings = {"05", "0x05"})
+  void existenceOf0xdoesntAffectcomparison(String otherValue) {
+    assertThat(comparator.compare("06", otherValue)).isEqualTo(1);
+    assertThat(comparator.compare(otherValue, "06")).isEqualTo(-1);
+
+    assertThat(comparator.compare("05", otherValue)).isEqualTo(0);
+    assertThat(comparator.compare("0x05", otherValue)).isEqualTo(0);
+    assertThat(comparator.compare(otherValue, "05")).isEqualTo(0);
+    assertThat(comparator.compare(otherValue, "0x05")).isEqualTo(0);
+  }
+
+  @Test
+  void nonHexStringThrowsException() {
+    final Throwable thrown = catchThrowable(() -> comparator.compare("NotHex", "0x01"));
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+}

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/util/HexStringComparatorTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/util/HexStringComparatorTest.java
@@ -9,8 +9,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 package tech.pegasys.ethsigner.core.util;
 
@@ -42,5 +40,4 @@ class HexStringComparatorTest {
     final Throwable thrown = catchThrowable(() -> comparator.compare("NotHex", "0x01"));
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
   }
-
 }


### PR DESCRIPTION
The MultikeyTomlSignerProvider currently ensures the name of the file loaded is the address of the key stored therein.

This restriction is to be lifted, allowing files to be named arbitrarily - mapping from an ethereum address --> key identifier must then be maintained within Ethsigner (but that is an issue for another day).