### PR TITLE
Prevent multiple transmission exceptions propogating

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/http/JsonRpcErrorHandler.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/http/JsonRpcErrorHandler.java
@@ -24,8 +24,12 @@ import javax.net.ssl.SSLException;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class JsonRpcErrorHandler implements Handler<RoutingContext> {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final HttpResponseFactory httpResponseFactory;
 
@@ -58,6 +62,7 @@ public class JsonRpcErrorHandler implements Handler<RoutingContext> {
             statusCode,
             JsonRpcError.CONNECTION_TO_DOWNSTREAM_NODE_TIMED_OUT);
       } else {
+        LOG.error("Unhandled exception handling request", failure);
         httpResponseFactory.failureResponse(
             context.response(), requestId, statusCode, JsonRpcError.INTERNAL_ERROR);
       }


### PR DESCRIPTION
There is a known behaviour in Vertx whereby, when a transmission timesout, two exceptions are raised by vertx, into the calling code.
This can, depending on thread priorities, mean that the second exception (VertxException: "connection closed") propogates, instead of the connection timeout.