### PR TITLE
Add --convert-eth-private-transactions-to-eea arg

### DIFF
--- a/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
+++ b/ethsigner/commandline/src/main/java/tech/pegasys/ethsigner/EthSignerBaseCommand.java
@@ -155,6 +155,15 @@ public class EthSignerBaseCommand implements Config, Runnable {
     this.downstreamHttpPath = path;
   }
 
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"--convert-eth-private-transactions-to-eea"},
+      description =
+          "If enabled, RPC calls to eth_sendTransaction will "
+              + "be forwarded as eea_sendRawTransaction if privacy "
+              + "arguments are enabled.")
+  private Boolean convertEthPrivateTransactionsToEea = false;
+
   // A list of origins URLs that are accepted by the JsonRpcHttpServer (CORS)
   @Option(
       names = {"--http-cors-origins"},
@@ -232,6 +241,11 @@ public class EthSignerBaseCommand implements Config, Runnable {
   @Override
   public Collection<String> getCorsAllowedOrigins() {
     return rpcHttpCorsAllowedOrigins;
+  }
+
+  @Override
+  public Boolean getConvertEthPrivateTransactionsToEea() {
+    return convertEthPrivateTransactionsToEea;
   }
 
   @Override

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/EthSigner.java
@@ -84,7 +84,8 @@ public final class EthSigner {
               jsonDecoder,
               config.getDataPath(),
               vertx,
-              config.getCorsAllowedOrigins());
+              config.getCorsAllowedOrigins(),
+              config.getConvertEthPrivateTransactionsToEea());
 
       runner.start();
     } catch (final Throwable t) {

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/Runner.java
@@ -73,6 +73,7 @@ public class Runner {
   private final Vertx vertx;
   private final Collection<String> allowedCorsOrigins;
   private final HttpServerOptions serverOptions;
+  private final boolean convertEthPrivateTransactionsToEea;
 
   public Runner(
       final long chainId,
@@ -84,7 +85,8 @@ public class Runner {
       final JsonDecoder jsonDecoder,
       final Path dataPath,
       final Vertx vertx,
-      final Collection<String> allowedCorsOrigins) {
+      final Collection<String> allowedCorsOrigins,
+      final boolean convertEthPrivateTransactionsToEea) {
     this.chainId = chainId;
     this.signerProvider = signerProvider;
     this.clientOptions = clientOptions;
@@ -95,6 +97,7 @@ public class Runner {
     this.vertx = vertx;
     this.allowedCorsOrigins = allowedCorsOrigins;
     this.serverOptions = serverOptions;
+    this.convertEthPrivateTransactionsToEea = convertEthPrivateTransactionsToEea;
   }
 
   public void start() throws ExecutionException, InterruptedException {
@@ -152,7 +155,7 @@ public class Runner {
       final VertxRequestTransmitterFactory transmitterFactory) {
     final PassThroughHandler defaultHandler = new PassThroughHandler(transmitterFactory);
     final TransactionFactory transactionFactory =
-        new TransactionFactory(jsonDecoder, transmitterFactory);
+        new TransactionFactory(jsonDecoder, transmitterFactory, convertEthPrivateTransactionsToEea);
 
     final SendTransactionHandler sendTransactionHandler =
         new SendTransactionHandler(chainId, signerProvider, transactionFactory, transmitterFactory);

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/config/Config.java
@@ -47,4 +47,6 @@ public interface Config {
   Optional<ClientTlsOptions> getClientTlsOptions();
 
   Collection<String> getCorsAllowedOrigins();
+
+  Boolean getConvertEthPrivateTransactionsToEea();
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParameters.java
@@ -12,19 +12,26 @@
  */
 package tech.pegasys.ethsigner.core.jsonrpc;
 
+import static org.web3j.utils.Numeric.decodeQuantity;
 import static tech.pegasys.ethsigner.core.jsonrpc.RpcUtil.decodeBigInteger;
+import static tech.pegasys.ethsigner.core.jsonrpc.RpcUtil.fromRpcRequestToJsonParam;
 import static tech.pegasys.ethsigner.core.jsonrpc.RpcUtil.validateNotEmpty;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import org.web3j.utils.Base64String;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EthSendTransactionJsonParameters {
+
   private final String sender;
   private BigInteger gas;
   private BigInteger gasPrice;
@@ -32,6 +39,11 @@ public class EthSendTransactionJsonParameters {
   private BigInteger value;
   private String receiver;
   private String data;
+
+  private Base64String privateFrom = null;
+  private List<Base64String> privateFor;
+  private String restriction = null;
+  private Base64String privacyGroupId;
 
   @JsonCreator
   public EthSendTransactionJsonParameters(@JsonProperty("from") final String sender) {
@@ -61,6 +73,7 @@ public class EthSendTransactionJsonParameters {
 
   @JsonSetter("value")
   public void value(final String value) {
+    validateValue(value);
     this.value = decodeBigInteger(value);
   }
 
@@ -93,7 +106,64 @@ public class EthSendTransactionJsonParameters {
     return Optional.ofNullable(nonce);
   }
 
+  @JsonProperty("from")
   public String sender() {
     return sender;
+  }
+
+  @JsonProperty("privateFrom")
+  public void privateFrom(String privateFrom) {
+    if (privateFrom != null) {
+      this.privateFrom = Base64String.wrap(privateFrom);
+    }
+  }
+
+  public Optional<Base64String> privateFrom() {
+    return Optional.ofNullable(privateFrom);
+  }
+
+  @JsonProperty("privateFor")
+  public void privateFor(final String[] privateFor) {
+    this.privateFor =
+        Arrays.stream(privateFor).map(Base64String::wrap).collect(Collectors.toList());
+  }
+
+  public Optional<List<Base64String>> privateFor() {
+    return Optional.ofNullable(privateFor);
+  }
+
+  @JsonProperty("privacyGroupId")
+  public void privacyGroupId(final String privacyGroupId) {
+    this.privacyGroupId = Base64String.wrap(privacyGroupId);
+  }
+
+  public Optional<Base64String> privacyGroupId() {
+    return Optional.ofNullable(privacyGroupId);
+  }
+
+  public void restriction(String restriction) {
+    this.restriction = restriction;
+  }
+
+  public Optional<String> restriction() {
+    return Optional.ofNullable(restriction);
+  }
+
+  public static EthSendTransactionJsonParameters from(final JsonRpcRequest request) {
+    return fromRpcRequestToJsonParam(EthSendTransactionJsonParameters.class, request);
+  }
+
+  public boolean isPrivate() {
+    return privacyGroupId().isPresent()
+        || privateFor().isPresent()
+        || privateFrom().isPresent()
+        || restriction().isPresent();
+  }
+
+  private void validateValue(final String value) {
+    if (isPrivate() && value != null && !decodeQuantity(value).equals(BigInteger.ZERO)) {
+      throw new IllegalArgumentException(
+          "Non-zero value, private transactions cannot transfer ether");
+    }
   }
 }

--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/TransactionFactory.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/TransactionFactory.java
@@ -32,11 +32,15 @@ public class TransactionFactory {
 
   private final VertxRequestTransmitterFactory transmitterFactory;
   private final JsonDecoder decoder;
+  private final boolean convertEthPrivateTransactionsToEea;
 
   public TransactionFactory(
-      final JsonDecoder decoder, final VertxRequestTransmitterFactory transmitterFactory) {
+      final JsonDecoder decoder,
+      final VertxRequestTransmitterFactory transmitterFactory,
+      final boolean convertEthPrivateTransactionsToEea) {
     this.transmitterFactory = transmitterFactory;
     this.decoder = decoder;
+    this.convertEthPrivateTransactionsToEea = convertEthPrivateTransactionsToEea;
   }
 
   public Transaction createTransaction(final RoutingContext context, final JsonRpcRequest request) {
@@ -58,6 +62,10 @@ public class TransactionFactory {
       final JsonRpcRequest request, final VertxNonceRequestTransmitter requestTransmitter) {
     final EthSendTransactionJsonParameters params =
         fromRpcRequestToJsonParam(EthSendTransactionJsonParameters.class, request);
+
+    if (convertEthPrivateTransactionsToEea && params.isPrivate()) {
+      return createEeaTransaction(request, requestTransmitter);
+    }
 
     final NonceProvider ethNonceProvider =
         new EthNonceProvider(params.sender(), requestTransmitter);

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParametersTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EeaSendTransactionJsonParametersTest.java
@@ -35,7 +35,7 @@ public class EeaSendTransactionJsonParametersTest {
   @BeforeEach
   public void setup() {
     // NOTE: the factory has been configured as per its use in the application.
-    factory = new TransactionFactory(EthSigner.createJsonDecoder(), null);
+    factory = new TransactionFactory(EthSigner.createJsonDecoder(), null, false);
   }
 
   @Test

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParametersTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpc/EthSendTransactionJsonParametersTest.java
@@ -31,7 +31,7 @@ public class EthSendTransactionJsonParametersTest {
   @BeforeEach
   public void setup() {
     // NOTE: the factory has been configured as per its use in the application.
-    factory = new TransactionFactory(EthSigner.createJsonDecoder(), null);
+    factory = new TransactionFactory(EthSigner.createJsonDecoder(), null, false);
   }
 
   private Optional<BigInteger> getStringAsOptionalBigInteger(

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/TransactionFactoryTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/requesthandler/sendtransaction/transaction/TransactionFactoryTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.ethsigner.core.requesthandler.sendtransaction.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import tech.pegasys.ethsigner.core.EthSigner;
+import tech.pegasys.ethsigner.core.jsonrpc.JsonRpcRequest;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TransactionFactoryTest {
+
+  private Object privateParams;
+  private Object publicParams;
+
+  private JsonRpcRequest privateRequest;
+  private JsonRpcRequest publicRequest;
+  RoutingContext context;
+
+  @BeforeEach
+  public void setup() {
+
+    privateParams =
+        new Object() {
+          public String from = "0x7577919ae5df4941180eac211965f275cdce314d";
+          public String privateFrom = "ZlapEsl9qDLPy/e88+/6yvCUEVIvH83y0N4A6wHuKXI=";
+          public String restriction = "restricted";
+          public String to = "0xd46e8dd67c5d32be8058bb8eb970870f07244567";
+          public String gas = "0x76c0";
+          public String gasPrice = "0x9184e72a000";
+          public String value = "0x0";
+          public String nonce = "0x1";
+          public String data =
+              "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675";
+          public String[] privateFor =
+              new String[] {"GV8m0VZAccYGAAYMBuYQtKEj0XtpXeaw2APcoBmtA2w="};
+        };
+
+    privateRequest = new JsonRpcRequest("2.0", "eth_sendTransaction");
+    privateRequest.setParams(privateParams);
+
+    publicParams =
+        new Object() {
+          public String from = "0x7577919ae5df4941180eac211965f275cdce314d";
+          public String to = "0xd46e8dd67c5d32be8058bb8eb970870f07244567";
+          public String gas = "0x76c0";
+          public String gasPrice = "0x9184e72a000";
+          public String value = "0x0";
+          public String nonce = "0x1";
+          public String data =
+              "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675";
+        };
+
+    publicRequest = new JsonRpcRequest("2.0", "eth_sendTransaction");
+    publicRequest.setParams(publicParams);
+
+    context = mock(RoutingContext.class);
+    final HttpServerRequest request = mock(HttpServerRequest.class);
+    final MultiMap headers = mock(MultiMap.class);
+
+    when(context.request()).thenReturn(request);
+    when(request.headers()).thenReturn(headers);
+  }
+
+  @Test
+  public void convertsEthPrivateTransactionsToEeaWhenAsked() {
+    final TransactionFactory factory =
+        new TransactionFactory(EthSigner.createJsonDecoder(), null, true);
+
+    Transaction privateTx = factory.createTransaction(context, privateRequest);
+    assertThat(privateTx).isInstanceOf(EeaPrivateTransaction.class);
+
+    Transaction publicTx = factory.createTransaction(context, publicRequest);
+    assertThat(publicTx).isInstanceOf(EthTransaction.class);
+  }
+
+  @Test
+  public void doesNotConvertEthPrivateTransactionsToEeaWhenAskedNotTo() {
+    final TransactionFactory factory =
+        new TransactionFactory(EthSigner.createJsonDecoder(), null, false);
+
+    Transaction privateTx = factory.createTransaction(context, privateRequest);
+    assertThat(privateTx).isInstanceOf(EthTransaction.class);
+
+    Transaction publicTx = factory.createTransaction(context, publicRequest);
+    assertThat(publicTx).isInstanceOf(EthTransaction.class);
+  }
+}

--- a/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
+++ b/ethsigner/subcommands/src/test/java/tech/pegasys/ethsigner/subcommands/HashicorpSubCommandTest.java
@@ -21,6 +21,7 @@ import static tech.pegasys.ethsigner.subcommands.HashicorpSubCommand.COMMAND_NAM
 
 import tech.pegasys.ethsigner.SignerSubCommand;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 public class HashicorpSubCommandTest extends SubCommandTestBase {
 
-  public static final String TLS_KNOWN_SERVER_FILE = "./knownServerFiles.txt";
+  public static final String TLS_KNOWN_SERVER_FILE = "." + File.separator + "knownServerFiles.txt";
   private static final String THIS_IS_THE_PATH_TO_THE_FILE =
       Paths.get("/this/is/the/path/to/the/file").toString();
   private static final String HTTP_HOST_COM = "http://host.com";


### PR DESCRIPTION
When enabled, calls to eth_sendTransaction with fields indicating that the transaction is meant to be private will be converted to eea_sendRawTransaction calls before sending to the client. This makes it possible to use tools like Truffle to send private transactions without refactoring them to use web3-eea.